### PR TITLE
Add frontend resolver for product detail fields

### DIFF
--- a/src/Infrastructure/Sulu/Content/Resolver/ProductDetailsResolver.php
+++ b/src/Infrastructure/Sulu/Content/Resolver/ProductDetailsResolver.php
@@ -41,13 +41,18 @@ class ProductDetailsResolver implements ResolverInterface
             return null;
         }
 
+        // entity master-data first; a project's `details/<field>` with a colliding bare
+        // name overrides it (array_merge — later keys win)
         return ContentView::create(
-            [
-                'code' => ContentView::create($dimensionContent->getCode(), []),
-                'externalIdentifier' => ContentView::create($dimensionContent->getExternalIdentifier(), []),
-                'productFamily' => ContentView::create($dimensionContent->getProductFamily()?->getUuid(), []),
-                'status' => ContentView::create($dimensionContent->getStatus(), []),
-            ] + $this->resolveDetailsData($dimensionContent),
+            \array_merge(
+                [
+                    'code' => ContentView::create($dimensionContent->getCode(), []),
+                    'externalIdentifier' => ContentView::create($dimensionContent->getExternalIdentifier(), []),
+                    'productFamily' => ContentView::create($dimensionContent->getProductFamily()?->getUuid(), []),
+                    'status' => ContentView::create($dimensionContent->getStatus(), []),
+                ],
+                $this->resolveDetailsData($dimensionContent),
+            ),
             [],
         );
     }
@@ -64,7 +69,8 @@ class ProductDetailsResolver implements ResolverInterface
     private function resolveDetailsData(ProductDimensionContentInterface $dimensionContent): array
     {
         // only merged content is resolved, and it always carries the localized row's locale
-        $locale = $dimensionContent->getLocale() ?? '';
+        /** @var string $locale */
+        $locale = $dimensionContent->getLocale();
 
         $formMetadata = $this->formMetadataLoader->getMetadata(ProductInterface::FORM_KEY, $locale, []);
         if (!$formMetadata instanceof FormMetadata) {

--- a/src/Infrastructure/Sulu/Content/Resolver/ProductDetailsResolver.php
+++ b/src/Infrastructure/Sulu/Content/Resolver/ProductDetailsResolver.php
@@ -41,8 +41,7 @@ class ProductDetailsResolver implements ResolverInterface
             return null;
         }
 
-        // entity master-data first; a project's `details/<field>` with a colliding bare
-        // name overrides it (array_merge — later keys win)
+        // a project's details/<field> overrides a colliding entity-field name
         return ContentView::create(
             \array_merge(
                 [
@@ -58,17 +57,14 @@ class ProductDetailsResolver implements ResolverInterface
     }
 
     /**
-     * Resolves every `details/<field>` through the property resolver selected by its XML `type`,
-     * exactly as `TemplateResolver` resolves template data. The bucket stores the admin wire-shape
-     * verbatim, so e.g. `single_media_selection` reaches `SingleMediaSelectionPropertyResolver`
-     * as the `{"id": …}` it expects, and a project's own `details/*` field resolves with no
-     * change to this class.
+     * Resolves each `details/<field>` through the property resolver its XML `type` selects, so the
+     * stored admin wire-shape (e.g. `{"id": …}`) reaches the matching resolver unchanged.
      *
      * @return array<string, ContentView>
      */
     private function resolveDetailsData(ProductDimensionContentInterface $dimensionContent): array
     {
-        // only merged content is resolved, and it always carries the localized row's locale
+        // merged content always carries a locale
         /** @var string $locale */
         $locale = $dimensionContent->getLocale();
 

--- a/src/Infrastructure/Sulu/Content/Resolver/ProductDetailsResolver.php
+++ b/src/Infrastructure/Sulu/Content/Resolver/ProductDetailsResolver.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Product\Infrastructure\Sulu\Content\Resolver;
+
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadataLoaderInterface;
+use Sulu\Content\Application\ContentResolver\Resolver\ResolverInterface;
+use Sulu\Content\Application\ContentResolver\Value\ContentView;
+use Sulu\Content\Application\MetadataResolver\MetadataResolver;
+use Sulu\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Product\Domain\Model\ProductDimensionContentInterface;
+use Sulu\Product\Domain\Model\ProductInterface;
+
+/**
+ * Exposes the product Details master-data fields to the frontend under `extension.product.*`.
+ *
+ * @internal
+ */
+class ProductDetailsResolver implements ResolverInterface
+{
+    public function __construct(
+        private readonly FormMetadataLoaderInterface $formMetadataLoader,
+        private readonly MetadataResolver $metadataResolver,
+    ) {
+    }
+
+    public function resolve(DimensionContentInterface $dimensionContent, ?array $properties = null): ?ContentView
+    {
+        if (!$dimensionContent instanceof ProductDimensionContentInterface) {
+            return null;
+        }
+
+        return ContentView::create(
+            [
+                'code' => ContentView::create($dimensionContent->getCode(), []),
+                'externalIdentifier' => ContentView::create($dimensionContent->getExternalIdentifier(), []),
+                'productFamily' => ContentView::create($dimensionContent->getProductFamily()?->getUuid(), []),
+                'status' => ContentView::create($dimensionContent->getStatus(), []),
+            ] + $this->resolveDetailsData($dimensionContent),
+            [],
+        );
+    }
+
+    /**
+     * Resolves every `details/<field>` through the property resolver selected by its XML `type`,
+     * exactly as `TemplateResolver` resolves template data. The bucket stores the admin wire-shape
+     * verbatim, so e.g. `single_media_selection` reaches `SingleMediaSelectionPropertyResolver`
+     * as the `{"id": …}` it expects, and a project's own `details/*` field resolves with no
+     * change to this class.
+     *
+     * @return array<string, ContentView>
+     */
+    private function resolveDetailsData(ProductDimensionContentInterface $dimensionContent): array
+    {
+        // only merged content is resolved, and it always carries the localized row's locale
+        $locale = $dimensionContent->getLocale() ?? '';
+
+        $formMetadata = $this->formMetadataLoader->getMetadata(ProductInterface::FORM_KEY, $locale, []);
+        if (!$formMetadata instanceof FormMetadata) {
+            return [];
+        }
+
+        $items = [];
+        foreach ($formMetadata->getFlatFieldMetadata() as $property) {
+            $parts = \explode('/', $property->getName(), 2);
+            if ('details' !== $parts[0] || !isset($parts[1])) {
+                continue;
+            }
+
+            // re-keyed to the bare field name — `resolveItems()` looks the value up by array key
+            $items[$parts[1]] = $property;
+        }
+
+        return $this->metadataResolver->resolveItems($items, $dimensionContent->getDetailsData(), $locale);
+    }
+}

--- a/src/Infrastructure/Sulu/Reference/ProductReferenceRefresher.php
+++ b/src/Infrastructure/Sulu/Reference/ProductReferenceRefresher.php
@@ -15,9 +15,6 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Query\Expr\Join;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadataLoaderInterface;
-use Sulu\Bundle\MediaBundle\Entity\MediaInterface;
 use Sulu\Bundle\ReferenceBundle\Application\Collector\ReferenceCollector;
 use Sulu\Bundle\ReferenceBundle\Application\Refresh\ReferenceRefresherInterface;
 use Sulu\Bundle\ReferenceBundle\Domain\Repository\ReferenceRepositoryInterface;
@@ -43,18 +40,11 @@ class ProductReferenceRefresher implements ReferenceRefresherInterface
      */
     private EntityRepository $productDimensionContentRepository;
 
-    /**
-     * Details media fields are stored as plain data and bypass the content-view resolve
-     * pipeline that normally feeds the reference index, so they are registered explicitly.
-     */
-    private const MEDIA_FIELD_TYPES = ['single_media_selection', 'media_selection'];
-
     public function __construct(
         private EntityManagerInterface $entityManager,
         private ReferenceRepositoryInterface $referenceRepository,
         private ContentViewResolverInterface $contentViewResolver,
         private ContentMergerInterface $contentMerger,
-        private FormMetadataLoaderInterface $formMetadataLoader,
     ) {
         /** @var EntityRepository<ProductDimensionContentInterface> $repository */
         $repository = $this->entityManager->getRepository(ProductDimensionContentInterface::class);
@@ -136,77 +126,7 @@ class ProductReferenceRefresher implements ReferenceRefresherInterface
             }
         }
 
-        $this->addDetailsMediaReferences($productDimensionContent, $referenceCollector);
-
         $referenceCollector->persistReferences();
-    }
-
-    /**
-     * Registers a reference for every media-typed `details/<field>` declared on the product
-     * details form, so a project's own media field is indexed without any bundle change.
-     */
-    private function addDetailsMediaReferences(
-        ProductDimensionContentInterface $productDimensionContent,
-        ReferenceCollector $referenceCollector,
-    ): void {
-        $detailsData = $productDimensionContent->getDetailsData();
-        if ([] === $detailsData) {
-            return;
-        }
-
-        $locale = $productDimensionContent->getLocale() ?? '';
-
-        $formMetadata = $this->formMetadataLoader->getMetadata(ProductInterface::FORM_KEY, $locale, []);
-        if (!$formMetadata instanceof FormMetadata) {
-            return;
-        }
-
-        foreach ($formMetadata->getFlatFieldMetadata() as $property) {
-            if (!\in_array($property->getType(), self::MEDIA_FIELD_TYPES, true)) {
-                continue;
-            }
-
-            $parts = \explode('/', $property->getName(), 2);
-            if ('details' !== $parts[0] || !isset($parts[1])) {
-                continue;
-            }
-
-            $field = $parts[1];
-            $value = $detailsData[$field] ?? null;
-            if (!\is_array($value)) {
-                continue;
-            }
-
-            if ('single_media_selection' === $property->getType()) {
-                $id = $value['id'] ?? null;
-                if (\is_int($id) || (\is_string($id) && \is_numeric($id))) {
-                    $referenceCollector->addReference(
-                        MediaInterface::RESOURCE_KEY,
-                        (string) $id,
-                        $field,
-                    );
-                }
-
-                continue;
-            }
-
-            $ids = $value['ids'] ?? null;
-            if (!\is_array($ids)) {
-                continue;
-            }
-
-            foreach ($ids as $index => $mediaId) {
-                if (!\is_int($mediaId) && !(\is_string($mediaId) && \is_numeric($mediaId))) {
-                    continue;
-                }
-
-                $referenceCollector->addReference(
-                    MediaInterface::RESOURCE_KEY,
-                    (string) $mediaId,
-                    $field . '/' . $index,
-                );
-            }
-        }
     }
 
     /**

--- a/src/Infrastructure/Symfony/HttpKernel/SuluProductBundle.php
+++ b/src/Infrastructure/Symfony/HttpKernel/SuluProductBundle.php
@@ -113,6 +113,7 @@ use Sulu\Product\Infrastructure\Sulu\Content\ProductSmartContentProvider;
 use Sulu\Product\Infrastructure\Sulu\Content\ProductTeaserProvider;
 use Sulu\Product\Infrastructure\Sulu\Content\PropertyResolver\ProductSelectionPropertyResolver;
 use Sulu\Product\Infrastructure\Sulu\Content\PropertyResolver\SingleProductSelectionPropertyResolver;
+use Sulu\Product\Infrastructure\Sulu\Content\Resolver\ProductDetailsResolver;
 use Sulu\Product\Infrastructure\Sulu\Content\ResourceLoader\ProductResourceLoader;
 use Sulu\Product\Infrastructure\Sulu\Content\Select\AttributeSelectService;
 use Sulu\Product\Infrastructure\Sulu\Content\Select\AttributeTypeSelectService;
@@ -776,6 +777,14 @@ final class SuluProductBundle extends AbstractBundle
         $services->set('sulu_product.product_selection_property_resolver')
             ->class(ProductSelectionPropertyResolver::class)
             ->tag('sulu_content.property_resolver');
+
+        $services->set('sulu_product.product_details_resolver')
+            ->class(ProductDetailsResolver::class)
+            ->args([
+                new Reference('sulu_admin.xml_form_metadata_loader'),
+                new Reference('sulu_content.metadata_resolver'),
+            ])
+            ->tag('sulu_content.content_resolver', ['type' => 'product']);
 
         $services->set('sulu_product.product_resource_loader')
             ->class(ProductResourceLoader::class)

--- a/src/Infrastructure/Symfony/HttpKernel/SuluProductBundle.php
+++ b/src/Infrastructure/Symfony/HttpKernel/SuluProductBundle.php
@@ -872,7 +872,6 @@ final class SuluProductBundle extends AbstractBundle
                 new Reference('sulu_reference.reference_repository'),
                 new Reference('sulu_content.content_view_resolver'),
                 new Reference('sulu_content.content_merger'),
-                new Reference('sulu_admin.xml_form_metadata_loader'),
             ])
             ->tag('sulu_reference.refresher');
 

--- a/tests/Functional/Content/ProductDetailsResolverTest.php
+++ b/tests/Functional/Content/ProductDetailsResolverTest.php
@@ -66,9 +66,7 @@ class ProductDetailsResolverTest extends SuluTestCase
         $dimensionContent = $product->createDimensionContent();
         $dimensionContent->setLocale('en');
         $dimensionContent->setStage('draft');
-        // ContentResolver's TemplateResolver requires a registered template key
-        // to resolve the (unrelated) template content section; "product" is the
-        // template registered for the frontend product template type in the test app.
+        // TemplateResolver needs a registered template key to resolve the template section
         $dimensionContent->setTemplateKey('product');
         $dimensionContent->setCode('SKU-FE');
         $dimensionContent->setStatus('available');
@@ -85,9 +83,8 @@ class ProductDetailsResolverTest extends SuluTestCase
         $productData = $result['extension']['product'];
         self::assertSame('SKU-FE', $productData['code']);
         self::assertSame('available', $productData['status']);
-        // resolved through the real property resolver registry, driven by the XML `type`
         self::assertSame('<p>hi</p>', $productData['shortDescription']);
-        // No media set → graceful empty shapes (missing media resolves the same way).
+        // no media set → empty shapes
         self::assertNull($productData['image']);
         self::assertSame([], $productData['documents']);
     }
@@ -104,7 +101,7 @@ class ProductDetailsResolverTest extends SuluTestCase
         $dimensionContent->setLocale('en');
         $dimensionContent->setStage('draft');
         $dimensionContent->setTemplateKey('product');
-        // the admin wire-shape, stored verbatim — the regression this whole change fixes
+        // admin wire-shape, stored verbatim
         $dimensionContent->setDetailsData(['image' => ['id' => $media->getId()]]);
         $product->addDimensionContent($dimensionContent);
 
@@ -115,9 +112,7 @@ class ProductDetailsResolverTest extends SuluTestCase
         $result = $this->contentResolver->resolve($dimensionContent);
         $productData = $result['extension']['product'];
 
-        // a bare int made SingleMediaSelectionPropertyResolver bail and emit id: null; storing
-        // the wire-shape verbatim means the id survives through to the media resource loader,
-        // which resolves it to the real media
+        // the wire-shape id survives to the resource loader and resolves to the real media
         $image = $productData['image'];
         self::assertInstanceOf(Media::class, $image);
         self::assertSame($media->getId(), $image->getId());

--- a/tests/Functional/Content/ProductDetailsResolverTest.php
+++ b/tests/Functional/Content/ProductDetailsResolverTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Product\Tests\Functional\Content;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\ResourceLoader\MediaResourceLoader;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Content\Application\ContentResolver\ContentResolverInterface;
+use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
+use Sulu\Product\Domain\Repository\ProductRepositoryInterface;
+
+class ProductDetailsResolverTest extends SuluTestCase
+{
+    private ContentResolverInterface $contentResolver;
+
+    private EntityManagerInterface $entityManager;
+
+    private ProductRepositoryInterface $productRepository;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $container = self::getContainer();
+
+        /** @var ContentResolverInterface $contentResolver */
+        $contentResolver = $container->get('sulu_content.content_resolver');
+        $this->contentResolver = $contentResolver;
+
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = $container->get('doctrine.orm.entity_manager');
+        $this->entityManager = $entityManager;
+
+        /** @var ProductRepositoryInterface $productRepository */
+        $productRepository = $container->get('sulu_product.product_repository');
+        $this->productRepository = $productRepository;
+
+        self::purgeDatabase();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        \restore_exception_handler();
+    }
+
+    public function testProductDetailsAppearUnderExtensionProduct(): void
+    {
+        $product = $this->productRepository->createNew();
+
+        $dimensionContent = $product->createDimensionContent();
+        $dimensionContent->setLocale('en');
+        $dimensionContent->setStage('draft');
+        // ContentResolver's TemplateResolver requires a registered template key
+        // to resolve the (unrelated) template content section; "product" is the
+        // template registered for the frontend product template type in the test app.
+        $dimensionContent->setTemplateKey('product');
+        $dimensionContent->setCode('SKU-FE');
+        $dimensionContent->setStatus('available');
+        $dimensionContent->setDetailsData(['shortDescription' => '<p>hi</p>']);
+        $product->addDimensionContent($dimensionContent);
+
+        $this->productRepository->add($product);
+        $this->entityManager->persist($dimensionContent);
+        $this->entityManager->flush();
+
+        $result = $this->contentResolver->resolve($dimensionContent);
+
+        self::assertArrayHasKey('product', $result['extension']);
+        $productData = $result['extension']['product'];
+        self::assertSame('SKU-FE', $productData['code']);
+        self::assertSame('available', $productData['status']);
+        // resolved through the real property resolver registry, driven by the XML `type`
+        self::assertSame('<p>hi</p>', $productData['shortDescription']);
+        // No media set → graceful empty shapes (missing media resolves the same way).
+        self::assertNull($productData['image']);
+        self::assertSame([], $productData['documents']);
+    }
+
+    public function testDetailsMediaResolvesThroughItsPropertyResolver(): void
+    {
+        $product = $this->productRepository->createNew();
+
+        $dimensionContent = $product->createDimensionContent();
+        $dimensionContent->setLocale('en');
+        $dimensionContent->setStage('draft');
+        $dimensionContent->setTemplateKey('product');
+        // the admin wire-shape, stored verbatim — the regression this whole change fixes
+        $dimensionContent->setDetailsData(['image' => ['id' => 1]]);
+        $product->addDimensionContent($dimensionContent);
+
+        $this->productRepository->add($product);
+        $this->entityManager->persist($dimensionContent);
+        $this->entityManager->flush();
+
+        $result = $this->contentResolver->resolve($dimensionContent);
+        $productData = $result['extension']['product'];
+
+        // a bare int made SingleMediaSelectionPropertyResolver bail and emit id: null; storing
+        // the wire-shape verbatim means the id now survives through to the media resource loader
+        $image = $productData['image'];
+        self::assertInstanceOf(ResolvableResource::class, $image);
+        self::assertSame(1, $image->getId());
+        self::assertSame(MediaResourceLoader::getKey(), $image->getResourceLoaderKey());
+    }
+}

--- a/tests/Functional/Content/ProductDetailsResolverTest.php
+++ b/tests/Functional/Content/ProductDetailsResolverTest.php
@@ -14,14 +14,19 @@ declare(strict_types=1);
 namespace Sulu\Product\Tests\Functional\Content;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\ResourceLoader\MediaResourceLoader;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Sulu\Bundle\MediaBundle\Api\Media;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Content\Application\ContentResolver\ContentResolverInterface;
-use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
+use Sulu\Content\Tests\Functional\Traits\CreateMediaTrait;
 use Sulu\Product\Domain\Repository\ProductRepositoryInterface;
+use Sulu\Product\Infrastructure\Sulu\Content\Resolver\ProductDetailsResolver;
 
+#[CoversClass(ProductDetailsResolver::class)]
 class ProductDetailsResolverTest extends SuluTestCase
 {
+    use CreateMediaTrait;
+
     private ContentResolverInterface $contentResolver;
 
     private EntityManagerInterface $entityManager;
@@ -89,6 +94,10 @@ class ProductDetailsResolverTest extends SuluTestCase
 
     public function testDetailsMediaResolvesThroughItsPropertyResolver(): void
     {
+        $collection = self::createCollection();
+        $media = self::createMedia($collection);
+        $this->entityManager->flush();
+
         $product = $this->productRepository->createNew();
 
         $dimensionContent = $product->createDimensionContent();
@@ -96,7 +105,7 @@ class ProductDetailsResolverTest extends SuluTestCase
         $dimensionContent->setStage('draft');
         $dimensionContent->setTemplateKey('product');
         // the admin wire-shape, stored verbatim — the regression this whole change fixes
-        $dimensionContent->setDetailsData(['image' => ['id' => 1]]);
+        $dimensionContent->setDetailsData(['image' => ['id' => $media->getId()]]);
         $product->addDimensionContent($dimensionContent);
 
         $this->productRepository->add($product);
@@ -107,10 +116,10 @@ class ProductDetailsResolverTest extends SuluTestCase
         $productData = $result['extension']['product'];
 
         // a bare int made SingleMediaSelectionPropertyResolver bail and emit id: null; storing
-        // the wire-shape verbatim means the id now survives through to the media resource loader
+        // the wire-shape verbatim means the id survives through to the media resource loader,
+        // which resolves it to the real media
         $image = $productData['image'];
-        self::assertInstanceOf(ResolvableResource::class, $image);
-        self::assertSame(1, $image->getId());
-        self::assertSame(MediaResourceLoader::getKey(), $image->getResourceLoaderKey());
+        self::assertInstanceOf(Media::class, $image);
+        self::assertSame($media->getId(), $image->getId());
     }
 }

--- a/tests/Unit/Infrastructure/Sulu/Content/Resolver/ProductDetailsResolverTest.php
+++ b/tests/Unit/Infrastructure/Sulu/Content/Resolver/ProductDetailsResolverTest.php
@@ -52,8 +52,7 @@ class ProductDetailsResolverTest extends TestCase
         $this->formMetadataLoader = $this->prophesize(FormMetadataLoaderInterface::class);
         $this->formMetadataLoader->getMetadata(Argument::cetera())->willReturn(null);
 
-        // the real property resolvers — the bucket is interpreted by the resolver its XML
-        // `type` selects, which is the whole point of storing the wire-shape verbatim
+        // real property resolvers, selected by each field's XML type
         $metadataResolver = new MetadataResolver(
             new PropertyResolverProvider(new \ArrayIterator([
                 'default' => new DefaultPropertyResolver(),
@@ -166,8 +165,7 @@ class ProductDetailsResolverTest extends TestCase
 
     public function testProjectDetailsFieldOverridesCollidingEntityField(): void
     {
-        // a project may reuse an entity field's bare name in the details bucket;
-        // the details field wins (array_merge — later keys override)
+        // a project's details/<field> overrides a colliding entity-field name
         $this->givenFormMetadata(['details/status' => 'text_line']);
 
         $dc = $this->makeDimensionContent(['status' => 'from-details']);
@@ -180,8 +178,7 @@ class ProductDetailsResolverTest extends TestCase
     {
         $this->givenFormMetadata(['details/image' => 'single_media_selection']);
 
-        // regression: the bucket stores {"id": 5} verbatim, so the property resolver gets the
-        // array it expects. Storing a bare 5 made it bail and emit id: null.
+        // {"id": 5} stored verbatim reaches the resolver as the array it expects
         $dc = $this->makeDimensionContent(['image' => ['id' => 5]]);
 
         $resolvable = $this->contentViewAt($dc, 'image')->getContent();
@@ -235,7 +232,6 @@ class ProductDetailsResolverTest extends TestCase
 
     public function testResolvesProjectDefinedBucketField(): void
     {
-        // a field the bundle knows nothing about, declared only in a project's form fragment
         $this->givenFormMetadata(['details/datasheet' => 'single_media_selection']);
 
         $dc = $this->makeDimensionContent(['datasheet' => ['id' => 77]]);

--- a/tests/Unit/Infrastructure/Sulu/Content/Resolver/ProductDetailsResolverTest.php
+++ b/tests/Unit/Infrastructure/Sulu/Content/Resolver/ProductDetailsResolverTest.php
@@ -149,7 +149,8 @@ class ProductDetailsResolverTest extends TestCase
         self::assertNull($this->contentViewAt($dc, 'code')->getContent());
         self::assertNull($this->contentViewAt($dc, 'externalIdentifier')->getContent());
         self::assertNull($this->contentViewAt($dc, 'productFamily')->getContent());
-        self::assertNull($this->contentViewAt($dc, 'status')->getContent());
+        // status is non-nullable and defaults to "available"
+        self::assertSame('available', $this->contentViewAt($dc, 'status')->getContent());
     }
 
     public function testResolvesBucketFieldByItsXmlType(): void

--- a/tests/Unit/Infrastructure/Sulu/Content/Resolver/ProductDetailsResolverTest.php
+++ b/tests/Unit/Infrastructure/Sulu/Content/Resolver/ProductDetailsResolverTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Product\Tests\Unit\Infrastructure\Sulu\Content\Resolver;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -36,6 +37,7 @@ use Sulu\Product\Domain\Model\ProductFamily;
 use Sulu\Product\Domain\Model\ProductInterface;
 use Sulu\Product\Infrastructure\Sulu\Content\Resolver\ProductDetailsResolver;
 
+#[CoversClass(ProductDetailsResolver::class)]
 class ProductDetailsResolverTest extends TestCase
 {
     use ProphecyTrait;
@@ -160,6 +162,18 @@ class ProductDetailsResolverTest extends TestCase
         $dc = $this->makeDimensionContent(['shortDescription' => '<p>hi</p>']);
 
         self::assertSame('<p>hi</p>', $this->contentViewAt($dc, 'shortDescription')->getContent());
+    }
+
+    public function testProjectDetailsFieldOverridesCollidingEntityField(): void
+    {
+        // a project may reuse an entity field's bare name in the details bucket;
+        // the details field wins (array_merge — later keys override)
+        $this->givenFormMetadata(['details/status' => 'text_line']);
+
+        $dc = $this->makeDimensionContent(['status' => 'from-details']);
+        $dc->setStatus('available');
+
+        self::assertSame('from-details', $this->contentViewAt($dc, 'status')->getContent());
     }
 
     public function testResolvesImageThroughSingleMediaSelectionPropertyResolver(): void

--- a/tests/Unit/Infrastructure/Sulu/Content/Resolver/ProductDetailsResolverTest.php
+++ b/tests/Unit/Infrastructure/Sulu/Content/Resolver/ProductDetailsResolverTest.php
@@ -1,0 +1,259 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Product\Tests\Unit\Infrastructure\Sulu\Content\Resolver;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadataLoaderInterface;
+use Sulu\Bundle\MediaBundle\Entity\MediaInterface;
+use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\PropertyResolver\MediaSelectionPropertyResolver;
+use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\PropertyResolver\SingleMediaSelectionPropertyResolver;
+use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\ResourceLoader\MediaResourceLoader;
+use Sulu\Content\Application\ContentResolver\Value\ContentView;
+use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
+use Sulu\Content\Application\MetadataResolver\MetadataResolver;
+use Sulu\Content\Application\PropertyResolver\PropertyResolverProvider;
+use Sulu\Content\Application\PropertyResolver\Resolver\DefaultPropertyResolver;
+use Sulu\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Product\Domain\Model\Product;
+use Sulu\Product\Domain\Model\ProductDimensionContent;
+use Sulu\Product\Domain\Model\ProductFamily;
+use Sulu\Product\Domain\Model\ProductInterface;
+use Sulu\Product\Infrastructure\Sulu\Content\Resolver\ProductDetailsResolver;
+
+class ProductDetailsResolverTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /** @var ObjectProphecy<FormMetadataLoaderInterface> */
+    private ObjectProphecy $formMetadataLoader;
+
+    private ProductDetailsResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->formMetadataLoader = $this->prophesize(FormMetadataLoaderInterface::class);
+        $this->formMetadataLoader->getMetadata(Argument::cetera())->willReturn(null);
+
+        // the real property resolvers — the bucket is interpreted by the resolver its XML
+        // `type` selects, which is the whole point of storing the wire-shape verbatim
+        $metadataResolver = new MetadataResolver(
+            new PropertyResolverProvider(new \ArrayIterator([
+                'default' => new DefaultPropertyResolver(),
+                'single_media_selection' => new SingleMediaSelectionPropertyResolver(),
+                'media_selection' => new MediaSelectionPropertyResolver(),
+            ])),
+        );
+
+        $this->resolver = new ProductDetailsResolver(
+            $this->formMetadataLoader->reveal(),
+            $metadataResolver,
+        );
+    }
+
+    /**
+     * @param array<string, string> $fields field name => type
+     */
+    private function givenFormMetadata(array $fields): void
+    {
+        $items = [];
+        foreach ($fields as $name => $type) {
+            $field = new FieldMetadata($name);
+            $field->setType($type);
+            $items[$name] = $field;
+        }
+
+        $formMetadata = new FormMetadata();
+        $formMetadata->setKey(ProductInterface::FORM_KEY);
+        $formMetadata->setItems($items);
+
+        $this->formMetadataLoader->getMetadata(ProductInterface::FORM_KEY, Argument::type('string'), [])
+            ->willReturn($formMetadata);
+    }
+
+    private function makeDimensionContent(mixed $details = []): ProductDimensionContent
+    {
+        $dimensionContent = new ProductDimensionContent(new Product());
+        $dimensionContent->setLocale('en');
+        /** @var array<string, mixed> $details */
+        $dimensionContent->setDetailsData($details);
+
+        return $dimensionContent;
+    }
+
+    /**
+     * @return array<mixed, mixed>
+     */
+    private function resolveContent(ProductDimensionContent $dimensionContent): array
+    {
+        $result = $this->resolver->resolve($dimensionContent);
+        self::assertInstanceOf(ContentView::class, $result);
+
+        $content = $result->getContent();
+        self::assertIsArray($content);
+
+        return $content;
+    }
+
+    private function contentViewAt(ProductDimensionContent $dimensionContent, string $key): ContentView
+    {
+        $view = $this->resolveContent($dimensionContent)[$key];
+        self::assertInstanceOf(ContentView::class, $view);
+
+        return $view;
+    }
+
+    public function testReturnsNullForNonProductDimensionContent(): void
+    {
+        $other = $this->prophesize(DimensionContentInterface::class);
+
+        self::assertNull($this->resolver->resolve($other->reveal()));
+    }
+
+    public function testResolvesEntityOwnedFields(): void
+    {
+        $family = new ProductFamily();
+        $family->setUuid('fam-uuid');
+
+        $dc = $this->makeDimensionContent();
+        $dc->setCode('SKU-1');
+        $dc->setExternalIdentifier('EXT-1');
+        $dc->setProductFamily($family);
+        $dc->setStatus('available');
+
+        self::assertSame('SKU-1', $this->contentViewAt($dc, 'code')->getContent());
+        self::assertSame('EXT-1', $this->contentViewAt($dc, 'externalIdentifier')->getContent());
+        self::assertSame('fam-uuid', $this->contentViewAt($dc, 'productFamily')->getContent());
+        self::assertSame('available', $this->contentViewAt($dc, 'status')->getContent());
+    }
+
+    public function testResolvesNullEntityOwnedFields(): void
+    {
+        $dc = $this->makeDimensionContent();
+
+        self::assertNull($this->contentViewAt($dc, 'code')->getContent());
+        self::assertNull($this->contentViewAt($dc, 'externalIdentifier')->getContent());
+        self::assertNull($this->contentViewAt($dc, 'productFamily')->getContent());
+        self::assertNull($this->contentViewAt($dc, 'status')->getContent());
+    }
+
+    public function testResolvesBucketFieldByItsXmlType(): void
+    {
+        $this->givenFormMetadata(['details/shortDescription' => 'text_editor']);
+
+        $dc = $this->makeDimensionContent(['shortDescription' => '<p>hi</p>']);
+
+        self::assertSame('<p>hi</p>', $this->contentViewAt($dc, 'shortDescription')->getContent());
+    }
+
+    public function testResolvesImageThroughSingleMediaSelectionPropertyResolver(): void
+    {
+        $this->givenFormMetadata(['details/image' => 'single_media_selection']);
+
+        // regression: the bucket stores {"id": 5} verbatim, so the property resolver gets the
+        // array it expects. Storing a bare 5 made it bail and emit id: null.
+        $dc = $this->makeDimensionContent(['image' => ['id' => 5]]);
+
+        $resolvable = $this->contentViewAt($dc, 'image')->getContent();
+
+        self::assertInstanceOf(ResolvableResource::class, $resolvable);
+        self::assertSame(5, $resolvable->getId());
+        self::assertSame(MediaResourceLoader::getKey(), $resolvable->getResourceLoaderKey());
+        self::assertSame(MediaInterface::RESOURCE_KEY, $resolvable->getResourceKey());
+        self::assertSame(-50, $resolvable->getPriority());
+    }
+
+    public function testResolvesEmptyImage(): void
+    {
+        $this->givenFormMetadata(['details/image' => 'single_media_selection']);
+
+        $imageView = $this->contentViewAt($this->makeDimensionContent(), 'image');
+
+        self::assertNull($imageView->getContent());
+        self::assertNull($imageView->getView()['id']);
+    }
+
+    public function testResolvesDocumentsThroughMediaSelectionPropertyResolver(): void
+    {
+        $this->givenFormMetadata(['details/documents' => 'media_selection']);
+
+        $dc = $this->makeDimensionContent(['documents' => ['ids' => [7, 9]]]);
+
+        $resolvables = $this->contentViewAt($dc, 'documents')->getContent();
+        self::assertIsArray($resolvables);
+        self::assertCount(2, $resolvables);
+
+        $first = $resolvables[0];
+        $second = $resolvables[1];
+        self::assertInstanceOf(ResolvableResource::class, $first);
+        self::assertInstanceOf(ResolvableResource::class, $second);
+
+        self::assertSame(7, $first->getId());
+        self::assertSame(9, $second->getId());
+        self::assertSame(MediaResourceLoader::getKey(), $first->getResourceLoaderKey());
+        self::assertSame(MediaInterface::RESOURCE_KEY, $first->getResourceKey());
+    }
+
+    public function testResolvesEmptyDocuments(): void
+    {
+        $this->givenFormMetadata(['details/documents' => 'media_selection']);
+
+        $documentsView = $this->contentViewAt($this->makeDimensionContent(), 'documents');
+
+        self::assertSame([], $documentsView->getContent());
+    }
+
+    public function testResolvesProjectDefinedBucketField(): void
+    {
+        // a field the bundle knows nothing about, declared only in a project's form fragment
+        $this->givenFormMetadata(['details/datasheet' => 'single_media_selection']);
+
+        $dc = $this->makeDimensionContent(['datasheet' => ['id' => 77]]);
+
+        $resolvable = $this->contentViewAt($dc, 'datasheet')->getContent();
+
+        self::assertInstanceOf(ResolvableResource::class, $resolvable);
+        self::assertSame(77, $resolvable->getId());
+    }
+
+    public function testIgnoresFormPropertiesOutsideTheDetailsBucket(): void
+    {
+        $this->givenFormMetadata([
+            'title' => 'text_line',
+            'details' => 'text_line',
+            'details/shortDescription' => 'text_editor',
+        ]);
+
+        $content = $this->resolveContent($this->makeDimensionContent(['shortDescription' => '<p>hi</p>']));
+
+        self::assertArrayHasKey('shortDescription', $content);
+        self::assertArrayNotHasKey('title', $content);
+    }
+
+    public function testResolvesWithoutDetailsWhenFormMetadataIsMissing(): void
+    {
+        // no givenFormMetadata() — the loader returns null for an unknown form
+        $dc = $this->makeDimensionContent(['shortDescription' => '<p>hi</p>']);
+        $dc->setCode('SKU-1');
+
+        $content = $this->resolveContent($dc);
+
+        self::assertArrayNotHasKey('shortDescription', $content);
+        self::assertArrayHasKey('code', $content);
+    }
+}

--- a/tests/Unit/Infrastructure/Sulu/Reference/ProductReferenceRefresherTest.php
+++ b/tests/Unit/Infrastructure/Sulu/Reference/ProductReferenceRefresherTest.php
@@ -19,9 +19,6 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadataLoaderInterface;
 use Sulu\Bundle\ReferenceBundle\Domain\Model\ReferenceInterface;
 use Sulu\Bundle\ReferenceBundle\Domain\Repository\ReferenceRepositoryInterface;
 use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
@@ -59,9 +56,6 @@ class ProductReferenceRefresherTest extends TestCase
     /** @var ObjectProphecy<EntityRepository<ProductDimensionContentInterface>> */
     private ObjectProphecy $productDimensionContentRepository;
 
-    /** @var ObjectProphecy<FormMetadataLoaderInterface> */
-    private ObjectProphecy $formMetadataLoader;
-
     protected function setUp(): void
     {
         $this->entityManager = $this->prophesize(EntityManagerInterface::class);
@@ -75,36 +69,12 @@ class ProductReferenceRefresherTest extends TestCase
         $this->entityManager->getRepository(ProductDimensionContentInterface::class)
             ->willReturn($this->productDimensionContentRepository->reveal());
 
-        $this->formMetadataLoader = $this->prophesize(FormMetadataLoaderInterface::class);
-        $this->formMetadataLoader->getMetadata(Argument::cetera())->willReturn(null);
-
         $this->refresher = new ProductReferenceRefresher(
             $this->entityManager->reveal(),
             $this->referenceRepository->reveal(),
             $this->contentViewResolver->reveal(),
             $this->contentMerger->reveal(),
-            $this->formMetadataLoader->reveal()
         );
-    }
-
-    /**
-     * @param array<string, string> $fields field name => type
-     */
-    private function givenFormMetadata(array $fields): void
-    {
-        $items = [];
-        foreach ($fields as $name => $type) {
-            $field = new FieldMetadata($name);
-            $field->setType($type);
-            $items[$name] = $field;
-        }
-
-        $formMetadata = new FormMetadata();
-        $formMetadata->setKey(ProductInterface::FORM_KEY);
-        $formMetadata->setItems($items);
-
-        $this->formMetadataLoader->getMetadata(ProductInterface::FORM_KEY, Argument::type('string'), [])
-            ->willReturn($formMetadata);
     }
 
     public function testGetResourceKey(): void
@@ -321,218 +291,6 @@ class ProductReferenceRefresherTest extends TestCase
         \iterator_to_array($this->refresher->refresh());
 
         $this->referenceRepository->add(Argument::type(ReferenceInterface::class))
-            ->shouldHaveBeenCalledOnce();
-    }
-
-    public function testRefreshRegistersDetailsMediaReferences(): void
-    {
-        $this->givenFormMetadata([
-            'details/shortDescription' => 'text_editor',
-            'details/image' => 'single_media_selection',
-            'details/documents' => 'media_selection',
-        ]);
-
-        $product = new Product('product-uuid-media');
-        $dimensionContent = new ProductDimensionContent($product);
-        $dimensionContent->setLocale('en');
-        $dimensionContent->setStage('live');
-        $dimensionContent->setDetailsData([
-            'shortDescription' => '<p>not a media field</p>',
-            'image' => ['id' => 42],
-            'documents' => ['ids' => [7, 9]],
-        ]);
-
-        $query = $this->stubQueryBuilderNoFilter();
-        $query->toIterable()->willReturn(new \ArrayIterator([$dimensionContent]));
-
-        $this->contentMerger->merge(Argument::type(DimensionContentCollection::class))
-            ->willReturn($dimensionContent);
-
-        // No template content references — only the Details media fields.
-        $this->contentViewResolver->getContentViews(Argument::any())
-            ->willReturn([]);
-
-        /** @var ObjectProphecy<ReferenceInterface> $referenceModel */
-        $referenceModel = $this->prophesize(ReferenceInterface::class);
-        $referenceModel->equals(Argument::any())->willReturn(false);
-
-        $this->referenceRepository->create(
-            Argument::type('string'),
-            Argument::type('string'),
-            Argument::type('string'),
-            Argument::type('string'),
-            Argument::type('string'),
-            Argument::type('string'),
-            Argument::type('string'),
-            Argument::type('string'),
-            Argument::type('array'),
-        )->willReturn($referenceModel->reveal());
-
-        $this->referenceRepository->removeBy(Argument::cetera());
-        $this->referenceRepository->add(Argument::type(ReferenceInterface::class));
-
-        \iterator_to_array($this->refresher->refresh());
-
-        // The image and both documents are registered as `media` references.
-        $this->referenceRepository->create('media', '42', Argument::cetera())
-            ->shouldHaveBeenCalledOnce();
-        $this->referenceRepository->create('media', '7', Argument::cetera())
-            ->shouldHaveBeenCalledOnce();
-        $this->referenceRepository->create('media', '9', Argument::cetera())
-            ->shouldHaveBeenCalledOnce();
-        // the non-media details field must not produce a reference
-        $this->referenceRepository->add(Argument::type(ReferenceInterface::class))
-            ->shouldHaveBeenCalledTimes(3);
-    }
-
-    /**
-     * Drives a full refresh over a single dimension content with no template content views,
-     * so only the details-media reference registration is exercised.
-     */
-    private function runRefreshWith(ProductDimensionContent $dimensionContent): void
-    {
-        $query = $this->stubQueryBuilderNoFilter();
-        $query->toIterable()->willReturn(new \ArrayIterator([$dimensionContent]));
-
-        $this->contentMerger->merge(Argument::type(DimensionContentCollection::class))
-            ->willReturn($dimensionContent);
-
-        $this->contentViewResolver->getContentViews(Argument::any())->willReturn([]);
-
-        /** @var ObjectProphecy<ReferenceInterface> $referenceModel */
-        $referenceModel = $this->prophesize(ReferenceInterface::class);
-        $referenceModel->equals(Argument::any())->willReturn(false);
-
-        $this->referenceRepository->create(
-            Argument::type('string'),
-            Argument::type('string'),
-            Argument::type('string'),
-            Argument::type('string'),
-            Argument::type('string'),
-            Argument::type('string'),
-            Argument::type('string'),
-            Argument::type('string'),
-            Argument::type('array'),
-        )->willReturn($referenceModel->reveal());
-
-        $this->referenceRepository->removeBy(Argument::cetera());
-        $this->referenceRepository->add(Argument::type(ReferenceInterface::class));
-
-        \iterator_to_array($this->refresher->refresh());
-    }
-
-    private function makeDimensionContentWithDetails(string $uuid, mixed $details, ?string $locale = 'en'): ProductDimensionContent
-    {
-        $dimensionContent = new ProductDimensionContent(new Product($uuid));
-        $dimensionContent->setLocale($locale);
-        $dimensionContent->setStage('live');
-        /** @var array<string, mixed> $details */
-        $dimensionContent->setDetailsData($details);
-
-        return $dimensionContent;
-    }
-
-    public function testRefreshNeverProcessesTheUnlocalizedRowOnItsOwn(): void
-    {
-        $this->givenFormMetadata(['details/image' => 'single_media_selection']);
-
-        // an unlocalized row is only ever merged into a localized one, never processed alone,
-        // which is why the merged content always carries a locale
-        $this->runRefreshWith($this->makeDimensionContentWithDetails('p-no-locale', ['image' => ['id' => 1]], null));
-
-        $this->referenceRepository->add(Argument::cetera())->shouldNotHaveBeenCalled();
-    }
-
-    public function testRefreshSkipsDetailsMediaWhenFormMetadataIsMissing(): void
-    {
-        // no givenFormMetadata() — the loader returns null for an unknown form
-        $this->runRefreshWith($this->makeDimensionContentWithDetails('p-no-form', ['image' => ['id' => 1]]));
-
-        $this->referenceRepository->add(Argument::cetera())->shouldNotHaveBeenCalled();
-    }
-
-    public function testRefreshIgnoresMediaFieldOutsideTheDetailsBucket(): void
-    {
-        // a media field that is not a details/* property must not be read from the bucket
-        $this->givenFormMetadata(['image' => 'single_media_selection']);
-
-        $this->runRefreshWith($this->makeDimensionContentWithDetails('p-bare', ['image' => ['id' => 1]]));
-
-        $this->referenceRepository->add(Argument::cetera())->shouldNotHaveBeenCalled();
-    }
-
-    public function testRefreshSkipsDetailsMediaWithNonArrayValue(): void
-    {
-        $this->givenFormMetadata(['details/image' => 'single_media_selection']);
-
-        // a legacy bare-id value predates the wire-shape storage and must not crash
-        $this->runRefreshWith($this->makeDimensionContentWithDetails('p-bare-id', ['image' => 5]));
-
-        $this->referenceRepository->add(Argument::cetera())->shouldNotHaveBeenCalled();
-    }
-
-    public function testRefreshSkipsMediaSelectionWithoutIdsList(): void
-    {
-        $this->givenFormMetadata(['details/documents' => 'media_selection']);
-
-        $this->runRefreshWith($this->makeDimensionContentWithDetails('p-no-ids', ['documents' => ['ids' => 'nope']]));
-
-        $this->referenceRepository->add(Argument::cetera())->shouldNotHaveBeenCalled();
-    }
-
-    public function testRefreshDropsNonNumericMediaIds(): void
-    {
-        $this->givenFormMetadata(['details/documents' => 'media_selection']);
-
-        $this->runRefreshWith($this->makeDimensionContentWithDetails('p-mixed', ['documents' => ['ids' => [4, 'abc', null]]]));
-
-        $this->referenceRepository->create('media', '4', Argument::cetera())->shouldHaveBeenCalledOnce();
-        $this->referenceRepository->add(Argument::type(ReferenceInterface::class))->shouldHaveBeenCalledOnce();
-    }
-
-    public function testRefreshRegistersProjectDefinedDetailsMediaField(): void
-    {
-        // a field the bundle knows nothing about, declared only in a project's form fragment
-        $this->givenFormMetadata([
-            'details/datasheet' => 'single_media_selection',
-        ]);
-
-        $product = new Product('product-uuid-datasheet');
-        $dimensionContent = new ProductDimensionContent($product);
-        $dimensionContent->setLocale('en');
-        $dimensionContent->setStage('live');
-        $dimensionContent->setDetailsData(['datasheet' => ['id' => 77]]);
-
-        $query = $this->stubQueryBuilderNoFilter();
-        $query->toIterable()->willReturn(new \ArrayIterator([$dimensionContent]));
-
-        $this->contentMerger->merge(Argument::type(DimensionContentCollection::class))
-            ->willReturn($dimensionContent);
-
-        $this->contentViewResolver->getContentViews(Argument::any())->willReturn([]);
-
-        /** @var ObjectProphecy<ReferenceInterface> $referenceModel */
-        $referenceModel = $this->prophesize(ReferenceInterface::class);
-        $referenceModel->equals(Argument::any())->willReturn(false);
-
-        $this->referenceRepository->create(
-            Argument::type('string'),
-            Argument::type('string'),
-            Argument::type('string'),
-            Argument::type('string'),
-            Argument::type('string'),
-            Argument::type('string'),
-            Argument::type('string'),
-            Argument::type('string'),
-            Argument::type('array'),
-        )->willReturn($referenceModel->reveal());
-
-        $this->referenceRepository->removeBy(Argument::cetera());
-        $this->referenceRepository->add(Argument::type(ReferenceInterface::class));
-
-        \iterator_to_array($this->refresher->refresh());
-
-        $this->referenceRepository->create('media', '77', Argument::cetera())
             ->shouldHaveBeenCalledOnce();
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

This adds a ProductDetailsResolver that exposes the product detail fields to the frontend under extension.product.*. The master data owned by the entity is resolved directly from the dimension content. Every field in the details bucket is resolved through the property resolver that its XML type selects, so stored media and other typed values arrive in their resolved shape. The manual media reference registration in ProductReferenceRefresher is removed because these references now flow through the same resolver pipeline.

#### Why?

The product detail fields were added in #393 but were only stored as plain data and were not available to frontend content resolution. Media fields were kept in their admin wire shape, so a resolver was needed to turn them into resolved values for the API. Registering those media references by hand was a workaround for the missing resolver and is no longer needed.

#### To Do

- [ ] Create a documentation PR
