### PR TITLE
Require sulu 3.0.8 for nested attribute validation schema

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "doctrine/dbal": "^3.9 || ^4.0",
         "doctrine/orm": "^2.17.3 || ^3.3",
         "sulu/messenger": "^1.0",
-        "sulu/sulu": "~3.0",
+        "sulu/sulu": "^3.0.8",
         "symfony/config": "^6.4 || ^7.1",
         "symfony/dependency-injection": "^6.4 || ^7.1",
         "symfony/event-dispatcher": "^6.4 || ^7.1",

--- a/tests/Unit/Infrastructure/Sulu/Admin/ProductAttributeFormMetadataVisitorTest.php
+++ b/tests/Unit/Infrastructure/Sulu/Admin/ProductAttributeFormMetadataVisitorTest.php
@@ -185,9 +185,14 @@ class ProductAttributeFormMetadataVisitorTest extends TestCase
                 [
                     'type' => 'object',
                     'properties' => [
-                        'attributes/7' => ['type' => 'number', 'minimum' => 0.0, 'maximum' => 10.0],
+                        'attributes' => [
+                            'type' => 'object',
+                            'properties' => [
+                                7 => ['type' => 'number', 'minimum' => 0.0, 'maximum' => 10.0],
+                            ],
+                            'required' => ['7'],
+                        ],
                     ],
-                    'required' => ['attributes/7'],
                 ],
             ],
         ], $schema);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Raise the `sulu/sulu` requirement to `^3.0.8` and update `ProductAttributeFormMetadataVisitorTest` to expect the nested JSON schema. The attribute fields use a name such as `attributes/7` and their submitted data lives under a nested `attributes` key. sulu 3.0.8 compiles that path into a nested object that carries its own properties and required list.

#### Why?

The attribute validation schema is only correct on sulu 3.0.8 and later. Older versions emit a flat `attributes/7` property that never matches the nested `attributes` data so client side validation does not apply. Raising the minimum version makes the lowest and highest dependency runs consistent and reflects the real requirement. The bundle is pre release so no released consumers are affected.

#### To Do

- [x] Create a documentation PR
