### PR TITLE
Group product attributes into per-group sections

### DIFF
--- a/src/Infrastructure/Sulu/Admin/ProductAttributeFormMetadataVisitor.php
+++ b/src/Infrastructure/Sulu/Admin/ProductAttributeFormMetadataVisitor.php
@@ -19,10 +19,10 @@ use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\SectionMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMapperRegistry;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SchemaMetadata;
+use Sulu\Product\Domain\Model\AttributeGroupInterface;
 use Sulu\Product\Domain\Model\ProductInterface;
 use Sulu\Product\Domain\Repository\ProductFamilyRepositoryInterface;
 use Sulu\Product\Domain\Repository\ProductRepositoryInterface;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * @internal
@@ -35,7 +35,6 @@ class ProductAttributeFormMetadataVisitor implements FormMetadataVisitorInterfac
         private readonly ProductFamilyRepositoryInterface $productFamilyRepository,
         private readonly AttributeFieldFactory $attributeFieldFactory,
         private readonly PropertyMetadataMapperRegistry $propertyMetadataMapperRegistry,
-        private readonly TranslatorInterface $translator,
         private readonly ProductRepositoryInterface $productRepository,
     ) {
     }
@@ -62,11 +61,10 @@ class ProductAttributeFormMetadataVisitor implements FormMetadataVisitorInterfac
 
         $items = $formMetadata->getItems();
 
+        /** @var array<int, SectionMetadata> $sections */
+        $sections = [];
         /** @var PropertyMetadata[] $schemaProperties */
         $schemaProperties = [];
-
-        $section = new SectionMetadata('attributes');
-        $section->setLabel($this->translator->trans('sulu_product.attributes', [], 'admin', $locale), $locale);
 
         foreach ($family->getFamilyAttributes() as $familyAttribute) {
             if ($isProductWithVariants && $familyAttribute->isVariantSpecific()) {
@@ -79,6 +77,14 @@ class ProductAttributeFormMetadataVisitor implements FormMetadataVisitorInterfac
             }
             [$field, $unitField] = $result;
 
+            $group = $familyAttribute->getAttribute()->getGroup();
+            $groupId = $group->getId();
+
+            if (!isset($sections[$groupId])) {
+                $sections[$groupId] = $this->createGroupSection($group, $locale);
+            }
+            $section = $sections[$groupId];
+
             $section->addItem($field);
 
             if (null !== $unitField) {
@@ -90,8 +96,10 @@ class ProductAttributeFormMetadataVisitor implements FormMetadataVisitorInterfac
                 : new PropertyMetadata($field->getName(), $field->isRequired());
         }
 
-        if ([] !== $section->getItems()) {
-            $items[$section->getName()] = $section;
+        if ([] !== $sections) {
+            foreach ($sections as $section) {
+                $items[$section->getName()] = $section;
+            }
             $formMetadata->setItems($items);
         }
 
@@ -100,5 +108,16 @@ class ProductAttributeFormMetadataVisitor implements FormMetadataVisitorInterfac
         }
 
         $formMetadata->setCacheable(false);
+    }
+
+    private function createGroupSection(AttributeGroupInterface $group, string $locale): SectionMetadata
+    {
+        $translation = $group->getTranslation($locale)
+            ?? (($defaultLocale = $group->getDefaultLocale()) !== null ? $group->getTranslation($defaultLocale) : null);
+
+        $section = new SectionMetadata('attribute_group_' . $group->getId());
+        $section->setLabel($translation?->getName() ?? '', $locale);
+
+        return $section;
     }
 }

--- a/src/Infrastructure/Sulu/Admin/ProductAttributeFormMetadataVisitor.php
+++ b/src/Infrastructure/Sulu/Admin/ProductAttributeFormMetadataVisitor.php
@@ -23,6 +23,7 @@ use Sulu\Product\Domain\Model\AttributeGroupInterface;
 use Sulu\Product\Domain\Model\ProductInterface;
 use Sulu\Product\Domain\Repository\ProductFamilyRepositoryInterface;
 use Sulu\Product\Domain\Repository\ProductRepositoryInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * @internal
@@ -35,6 +36,7 @@ class ProductAttributeFormMetadataVisitor implements FormMetadataVisitorInterfac
         private readonly ProductFamilyRepositoryInterface $productFamilyRepository,
         private readonly AttributeFieldFactory $attributeFieldFactory,
         private readonly PropertyMetadataMapperRegistry $propertyMetadataMapperRegistry,
+        private readonly TranslatorInterface $translator,
         private readonly ProductRepositoryInterface $productRepository,
     ) {
     }
@@ -114,9 +116,11 @@ class ProductAttributeFormMetadataVisitor implements FormMetadataVisitorInterfac
     {
         $translation = $group->getTranslation($locale)
             ?? (($defaultLocale = $group->getDefaultLocale()) !== null ? $group->getTranslation($defaultLocale) : null);
+        $name = $translation?->getName()
+            ?: $this->translator->trans('sulu_product.attributes', [], 'admin', $locale);
 
         $section = new SectionMetadata('attribute_group_' . $group->getId());
-        $section->setLabel($translation?->getName() ?? '', $locale);
+        $section->setLabel($name, $locale);
 
         return $section;
     }

--- a/src/Infrastructure/Sulu/Admin/ProductVariantAttributeFormMetadataVisitor.php
+++ b/src/Infrastructure/Sulu/Admin/ProductVariantAttributeFormMetadataVisitor.php
@@ -21,6 +21,7 @@ use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMapperRegist
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SchemaMetadata;
 use Sulu\Product\Domain\Model\AttributeGroupInterface;
 use Sulu\Product\Domain\Repository\ProductFamilyRepositoryInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Injects the parent product family's `variant=true` (axis) attributes into the variant overlay
@@ -37,6 +38,7 @@ class ProductVariantAttributeFormMetadataVisitor implements FormMetadataVisitorI
         private readonly ProductFamilyRepositoryInterface $productFamilyRepository,
         private readonly AttributeFieldFactory $attributeFieldFactory,
         private readonly PropertyMetadataMapperRegistry $propertyMetadataMapperRegistry,
+        private readonly TranslatorInterface $translator,
     ) {
     }
 
@@ -112,9 +114,11 @@ class ProductVariantAttributeFormMetadataVisitor implements FormMetadataVisitorI
     {
         $translation = $group->getTranslation($locale)
             ?? (($defaultLocale = $group->getDefaultLocale()) !== null ? $group->getTranslation($defaultLocale) : null);
+        $name = $translation?->getName()
+            ?: $this->translator->trans('sulu_product.attributes', [], 'admin', $locale);
 
         $section = new SectionMetadata('attribute_group_' . $group->getId());
-        $section->setLabel($translation?->getName() ?? '', $locale);
+        $section->setLabel($name, $locale);
 
         return $section;
     }

--- a/src/Infrastructure/Sulu/Admin/ProductVariantAttributeFormMetadataVisitor.php
+++ b/src/Infrastructure/Sulu/Admin/ProductVariantAttributeFormMetadataVisitor.php
@@ -19,12 +19,13 @@ use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\SectionMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMapperRegistry;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SchemaMetadata;
+use Sulu\Product\Domain\Model\AttributeGroupInterface;
 use Sulu\Product\Domain\Repository\ProductFamilyRepositoryInterface;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Injects the parent product family's `variant=true` (axis) attributes into the variant overlay
- * form (`product_variant`); non-variant (shared) attributes are never injected.
+ * form (`product_variant`), grouped into a section per attribute group; non-variant (shared)
+ * attributes are never injected.
  *
  * @internal
  */
@@ -36,7 +37,6 @@ class ProductVariantAttributeFormMetadataVisitor implements FormMetadataVisitorI
         private readonly ProductFamilyRepositoryInterface $productFamilyRepository,
         private readonly AttributeFieldFactory $attributeFieldFactory,
         private readonly PropertyMetadataMapperRegistry $propertyMetadataMapperRegistry,
-        private readonly TranslatorInterface $translator,
     ) {
     }
 
@@ -59,11 +59,10 @@ class ProductVariantAttributeFormMetadataVisitor implements FormMetadataVisitorI
 
         $items = $formMetadata->getItems();
 
+        /** @var array<int, SectionMetadata> $sections */
+        $sections = [];
         /** @var PropertyMetadata[] $schemaProperties */
         $schemaProperties = [];
-
-        $section = new SectionMetadata('attributes');
-        $section->setLabel($this->translator->trans('sulu_product.attributes', [], 'admin', $locale), $locale);
 
         foreach ($family->getFamilyAttributes() as $familyAttribute) {
             if (!$familyAttribute->isVariantSpecific()) {
@@ -76,6 +75,14 @@ class ProductVariantAttributeFormMetadataVisitor implements FormMetadataVisitorI
             }
             [$field, $unitField] = $result;
 
+            $group = $familyAttribute->getAttribute()->getGroup();
+            $groupId = $group->getId();
+
+            if (!isset($sections[$groupId])) {
+                $sections[$groupId] = $this->createGroupSection($group, $locale);
+            }
+            $section = $sections[$groupId];
+
             $section->addItem($field);
 
             if (null !== $unitField) {
@@ -87,8 +94,10 @@ class ProductVariantAttributeFormMetadataVisitor implements FormMetadataVisitorI
                 : new PropertyMetadata($field->getName(), $field->isRequired());
         }
 
-        if ([] !== $section->getItems()) {
-            $items[$section->getName()] = $section;
+        if ([] !== $sections) {
+            foreach ($sections as $section) {
+                $items[$section->getName()] = $section;
+            }
             $formMetadata->setItems($items);
         }
 
@@ -97,5 +106,16 @@ class ProductVariantAttributeFormMetadataVisitor implements FormMetadataVisitorI
         }
 
         $formMetadata->setCacheable(false);
+    }
+
+    private function createGroupSection(AttributeGroupInterface $group, string $locale): SectionMetadata
+    {
+        $translation = $group->getTranslation($locale)
+            ?? (($defaultLocale = $group->getDefaultLocale()) !== null ? $group->getTranslation($defaultLocale) : null);
+
+        $section = new SectionMetadata('attribute_group_' . $group->getId());
+        $section->setLabel($translation?->getName() ?? '', $locale);
+
+        return $section;
     }
 }

--- a/src/Infrastructure/Symfony/HttpKernel/SuluProductBundle.php
+++ b/src/Infrastructure/Symfony/HttpKernel/SuluProductBundle.php
@@ -830,7 +830,6 @@ final class SuluProductBundle extends AbstractBundle
                 new Reference('sulu_product.product_family_repository'),
                 new Reference('sulu_product.attribute_field_factory'),
                 new Reference('sulu_admin.property_metadata_mapper_registry'),
-                new Reference('translator'),
                 new Reference('sulu_product.product_repository'),
             ])
             ->tag('sulu_admin.form_metadata_visitor');
@@ -841,7 +840,6 @@ final class SuluProductBundle extends AbstractBundle
                 new Reference('sulu_product.product_family_repository'),
                 new Reference('sulu_product.attribute_field_factory'),
                 new Reference('sulu_admin.property_metadata_mapper_registry'),
-                new Reference('translator'),
             ])
             ->tag('sulu_admin.form_metadata_visitor');
 

--- a/src/Infrastructure/Symfony/HttpKernel/SuluProductBundle.php
+++ b/src/Infrastructure/Symfony/HttpKernel/SuluProductBundle.php
@@ -830,6 +830,7 @@ final class SuluProductBundle extends AbstractBundle
                 new Reference('sulu_product.product_family_repository'),
                 new Reference('sulu_product.attribute_field_factory'),
                 new Reference('sulu_admin.property_metadata_mapper_registry'),
+                new Reference('translator'),
                 new Reference('sulu_product.product_repository'),
             ])
             ->tag('sulu_admin.form_metadata_visitor');
@@ -840,6 +841,7 @@ final class SuluProductBundle extends AbstractBundle
                 new Reference('sulu_product.product_family_repository'),
                 new Reference('sulu_product.attribute_field_factory'),
                 new Reference('sulu_admin.property_metadata_mapper_registry'),
+                new Reference('translator'),
             ])
             ->tag('sulu_admin.form_metadata_visitor');
 

--- a/tests/Unit/Infrastructure/Sulu/Admin/ProductAttributeFormMetadataVisitorTest.php
+++ b/tests/Unit/Infrastructure/Sulu/Admin/ProductAttributeFormMetadataVisitorTest.php
@@ -27,6 +27,8 @@ use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMapperRegist
 use Sulu\Product\Application\AttributeType\AttributeTypeRegistry;
 use Sulu\Product\Application\AttributeType\NumberAttributeType;
 use Sulu\Product\Domain\Measurement\MeasurementRegistry;
+use Sulu\Product\Domain\Model\AttributeGroupInterface;
+use Sulu\Product\Domain\Model\AttributeGroupTranslationInterface;
 use Sulu\Product\Domain\Model\AttributeInterface;
 use Sulu\Product\Domain\Model\AttributeTranslationInterface;
 use Sulu\Product\Domain\Model\Product;
@@ -78,9 +80,20 @@ class ProductAttributeFormMetadataVisitorTest extends TestCase
                 $translator,
             ),
             new PropertyMetadataMapperRegistry($mapperContainer),
-            $translator,
             $this->productRepository->reveal(),
         );
+    }
+
+    private function group(int $id = 1, string $name = 'Dimensions'): AttributeGroupInterface
+    {
+        $translation = $this->prophesize(AttributeGroupTranslationInterface::class);
+        $translation->getName()->willReturn($name);
+
+        $group = $this->prophesize(AttributeGroupInterface::class);
+        $group->getId()->willReturn($id);
+        $group->getTranslation('en')->willReturn($translation->reveal());
+
+        return $group->reveal();
     }
 
     private function fragmentWithValueField(): FormMetadata
@@ -128,6 +141,7 @@ class ProductAttributeFormMetadataVisitorTest extends TestCase
         $attribute->getType()->willReturn(AttributeInterface::TYPE_NUMBER);
         $attribute->getConfig()->willReturn([]);
         $attribute->getTranslation('en')->willReturn($translation->reveal());
+        $attribute->getGroup()->willReturn($this->group());
 
         $familyAttribute = $this->prophesize(ProductFamilyAttributeInterface::class);
         $familyAttribute->getAttribute()->willReturn($attribute->reveal());
@@ -146,8 +160,8 @@ class ProductAttributeFormMetadataVisitorTest extends TestCase
         $this->visitor()->visitFormMetadata($form, 'en', ['id' => 'uuid-1']);
 
         $items = $form->getItems();
-        self::assertArrayHasKey('attributes', $items);
-        $section = $items['attributes'];
+        self::assertArrayHasKey('attribute_group_1', $items);
+        $section = $items['attribute_group_1'];
         self::assertInstanceOf(SectionMetadata::class, $section);
         $sectionItems = $section->getItems();
         self::assertArrayHasKey('attributes/7', $sectionItems);
@@ -172,6 +186,7 @@ class ProductAttributeFormMetadataVisitorTest extends TestCase
         $attribute->getType()->willReturn(AttributeInterface::TYPE_NUMBER);
         $attribute->getConfig()->willReturn(['min' => 0, 'max' => 10]);
         $attribute->getTranslation('en')->willReturn($translation->reveal());
+        $attribute->getGroup()->willReturn($this->group());
 
         $familyAttribute = $this->prophesize(ProductFamilyAttributeInterface::class);
         $familyAttribute->getAttribute()->willReturn($attribute->reveal());
@@ -222,6 +237,7 @@ class ProductAttributeFormMetadataVisitorTest extends TestCase
         $attribute->getType()->willReturn(AttributeInterface::TYPE_NUMBER);
         $attribute->getConfig()->willReturn([]);
         $attribute->getTranslation('en')->willReturn($translation->reveal());
+        $attribute->getGroup()->willReturn($this->group());
 
         $familyAttribute = $this->prophesize(ProductFamilyAttributeInterface::class);
         $familyAttribute->getAttribute()->willReturn($attribute->reveal());
@@ -239,7 +255,7 @@ class ProductAttributeFormMetadataVisitorTest extends TestCase
 
         $this->visitor()->visitFormMetadata($form, 'en', ['id' => 'uuid-1']);
 
-        $section = $form->getItems()['attributes'];
+        $section = $form->getItems()['attribute_group_1'];
         self::assertInstanceOf(SectionMetadata::class, $section);
         $field = $section->getItems()['attributes/7'];
         self::assertInstanceOf(FieldMetadata::class, $field);
@@ -303,6 +319,7 @@ class ProductAttributeFormMetadataVisitorTest extends TestCase
         $attribute->getType()->willReturn(AttributeInterface::TYPE_NUMBER);
         $attribute->getConfig()->willReturn([]);
         $attribute->getTranslation('en')->willReturn($translation->reveal());
+        $attribute->getGroup()->willReturn($this->group());
 
         $familyAttribute = $this->prophesize(ProductFamilyAttributeInterface::class);
         $familyAttribute->getAttribute()->willReturn($attribute->reveal());
@@ -332,7 +349,7 @@ class ProductAttributeFormMetadataVisitorTest extends TestCase
 
         $this->visitor()->visitFormMetadata($form, 'en', ['id' => 'uuid-1']);
 
-        $section = $form->getItems()['attributes'];
+        $section = $form->getItems()['attribute_group_1'];
         self::assertInstanceOf(SectionMetadata::class, $section);
         $injected = $section->getItems()['attributes/7'];
         self::assertInstanceOf(FieldMetadata::class, $injected);
@@ -381,6 +398,7 @@ class ProductAttributeFormMetadataVisitorTest extends TestCase
         $attribute->getType()->willReturn(AttributeInterface::TYPE_NUMBER);
         $attribute->getConfig()->willReturn(['unit' => 'KILOGRAM']);
         $attribute->getTranslation('en')->willReturn($translation->reveal());
+        $attribute->getGroup()->willReturn($this->group());
 
         $familyAttribute = $this->prophesize(ProductFamilyAttributeInterface::class);
         $familyAttribute->getAttribute()->willReturn($attribute->reveal());
@@ -398,7 +416,7 @@ class ProductAttributeFormMetadataVisitorTest extends TestCase
 
         $this->visitor()->visitFormMetadata($form, 'en', ['id' => 'uuid-1']);
 
-        $section = $form->getItems()['attributes'];
+        $section = $form->getItems()['attribute_group_1'];
         self::assertInstanceOf(SectionMetadata::class, $section);
         $sectionItems = $section->getItems();
 
@@ -448,6 +466,7 @@ class ProductAttributeFormMetadataVisitorTest extends TestCase
         $attribute->getType()->willReturn(AttributeInterface::TYPE_NUMBER);
         $attribute->getConfig()->willReturn($config);
         $attribute->getTranslation('en')->willReturn($translation->reveal());
+        $attribute->getGroup()->willReturn($this->group());
 
         $familyAttribute = $this->prophesize(ProductFamilyAttributeInterface::class);
         $familyAttribute->getAttribute()->willReturn($attribute->reveal());
@@ -465,7 +484,7 @@ class ProductAttributeFormMetadataVisitorTest extends TestCase
 
         $this->visitor()->visitFormMetadata($form, 'en', ['id' => 'uuid-1']);
 
-        $section = $form->getItems()['attributes'];
+        $section = $form->getItems()['attribute_group_1'];
         self::assertInstanceOf(SectionMetadata::class, $section);
         $sectionItems = $section->getItems();
         self::assertArrayHasKey('attributes/7', $sectionItems);
@@ -499,6 +518,7 @@ class ProductAttributeFormMetadataVisitorTest extends TestCase
         $attribute->getTranslation('en')->willReturn(null);
         $attribute->getDefaultLocale()->willReturn('de');
         $attribute->getTranslation('de')->willReturn($fallbackTranslation->reveal());
+        $attribute->getGroup()->willReturn($this->group());
 
         $familyAttribute = $this->prophesize(ProductFamilyAttributeInterface::class);
         $familyAttribute->getAttribute()->willReturn($attribute->reveal());
@@ -516,7 +536,7 @@ class ProductAttributeFormMetadataVisitorTest extends TestCase
 
         $this->visitor()->visitFormMetadata($form, 'en', ['id' => 'uuid-1']);
 
-        $section = $form->getItems()['attributes'];
+        $section = $form->getItems()['attribute_group_1'];
         self::assertInstanceOf(SectionMetadata::class, $section);
         $field = $section->getItems()['attributes/7'];
         self::assertInstanceOf(FieldMetadata::class, $field);
@@ -535,6 +555,7 @@ class ProductAttributeFormMetadataVisitorTest extends TestCase
         $attribute->getType()->willReturn(AttributeInterface::TYPE_NUMBER);
         $attribute->getConfig()->willReturn([]);
         $attribute->getTranslation('en')->willReturn($translation->reveal());
+        $attribute->getGroup()->willReturn($this->group());
 
         $nonVariantFamilyAttribute = $this->prophesize(ProductFamilyAttributeInterface::class);
         $nonVariantFamilyAttribute->isVariantSpecific()->willReturn(false);
@@ -563,10 +584,73 @@ class ProductAttributeFormMetadataVisitorTest extends TestCase
 
         $this->visitor()->visitFormMetadata($form, 'en', ['id' => 'uuid-1']);
 
-        $section = $form->getItems()['attributes'];
+        $section = $form->getItems()['attribute_group_1'];
         self::assertInstanceOf(SectionMetadata::class, $section);
         $sectionItems = $section->getItems();
         self::assertArrayHasKey('attributes/7', $sectionItems);
         self::assertArrayNotHasKey('attributes/8', $sectionItems);
+    }
+
+    public function testGroupsAttributesIntoSeparateSectionsPerGroup(): void
+    {
+        $translation7 = $this->prophesize(AttributeTranslationInterface::class);
+        $translation7->getName()->willReturn('Weight');
+        $translation7->getDescription()->willReturn(null);
+
+        $attribute7 = $this->prophesize(AttributeInterface::class);
+        $attribute7->getId()->willReturn(7);
+        $attribute7->getKey()->willReturn('weight');
+        $attribute7->getType()->willReturn(AttributeInterface::TYPE_NUMBER);
+        $attribute7->getConfig()->willReturn([]);
+        $attribute7->getTranslation('en')->willReturn($translation7->reveal());
+        $attribute7->getGroup()->willReturn($this->group(1, 'Dimensions'));
+
+        $familyAttribute7 = $this->prophesize(ProductFamilyAttributeInterface::class);
+        $familyAttribute7->getAttribute()->willReturn($attribute7->reveal());
+        $familyAttribute7->isRequired()->willReturn(false);
+
+        $translation8 = $this->prophesize(AttributeTranslationInterface::class);
+        $translation8->getName()->willReturn('Voltage');
+        $translation8->getDescription()->willReturn(null);
+
+        $attribute8 = $this->prophesize(AttributeInterface::class);
+        $attribute8->getId()->willReturn(8);
+        $attribute8->getKey()->willReturn('voltage');
+        $attribute8->getType()->willReturn(AttributeInterface::TYPE_NUMBER);
+        $attribute8->getConfig()->willReturn([]);
+        $attribute8->getTranslation('en')->willReturn($translation8->reveal());
+        $attribute8->getGroup()->willReturn($this->group(2, 'Electrical'));
+
+        $familyAttribute8 = $this->prophesize(ProductFamilyAttributeInterface::class);
+        $familyAttribute8->getAttribute()->willReturn($attribute8->reveal());
+        $familyAttribute8->isRequired()->willReturn(false);
+
+        $family = $this->prophesize(ProductFamilyInterface::class);
+        $family->getFamilyAttributes()->willReturn([
+            $familyAttribute7->reveal(),
+            $familyAttribute8->reveal(),
+        ]);
+
+        $this->productFamilyRepository->findOneBy(['productUuid' => 'uuid-1'])->willReturn($family->reveal());
+        $this->formMetadataLoader->getMetadata('product_attribute_number', 'en', [])
+            ->willReturn($this->fragmentWithValueField());
+
+        $form = new FormMetadata();
+        $form->setKey('product_details');
+
+        $this->visitor()->visitFormMetadata($form, 'en', ['id' => 'uuid-1']);
+
+        $items = $form->getItems();
+        self::assertArrayHasKey('attribute_group_1', $items);
+        self::assertArrayHasKey('attribute_group_2', $items);
+
+        $sectionOne = $items['attribute_group_1'];
+        self::assertInstanceOf(SectionMetadata::class, $sectionOne);
+        self::assertArrayHasKey('attributes/7', $sectionOne->getItems());
+        self::assertArrayNotHasKey('attributes/8', $sectionOne->getItems());
+
+        $sectionTwo = $items['attribute_group_2'];
+        self::assertInstanceOf(SectionMetadata::class, $sectionTwo);
+        self::assertArrayHasKey('attributes/8', $sectionTwo->getItems());
     }
 }

--- a/tests/Unit/Infrastructure/Sulu/Admin/ProductAttributeFormMetadataVisitorTest.php
+++ b/tests/Unit/Infrastructure/Sulu/Admin/ProductAttributeFormMetadataVisitorTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sulu\Product\Tests\Unit\Infrastructure\Sulu\Admin;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
@@ -69,7 +70,12 @@ class ProductAttributeFormMetadataVisitorTest extends TestCase
         $mapperContainer->set('number', new NumberPropertyMetadataMapper());
 
         $translator = $this->createStub(TranslatorInterface::class);
-        $translator->method('trans')->willReturn('Unit');
+        $translator->method('trans')->willReturnCallback(
+            static fn (string $id): string => match ($id) {
+                'sulu_product.attributes' => 'Attributes',
+                default => 'Unit',
+            },
+        );
 
         return new ProductAttributeFormMetadataVisitor(
             $this->productFamilyRepository->reveal(),
@@ -80,18 +86,25 @@ class ProductAttributeFormMetadataVisitorTest extends TestCase
                 $translator,
             ),
             new PropertyMetadataMapperRegistry($mapperContainer),
+            $translator,
             $this->productRepository->reveal(),
         );
     }
 
-    private function group(int $id = 1, string $name = 'Dimensions'): AttributeGroupInterface
+    private function group(int $id = 1, ?string $name = 'Dimensions'): AttributeGroupInterface
     {
-        $translation = $this->prophesize(AttributeGroupTranslationInterface::class);
-        $translation->getName()->willReturn($name);
-
         $group = $this->prophesize(AttributeGroupInterface::class);
         $group->getId()->willReturn($id);
-        $group->getTranslation('en')->willReturn($translation->reveal());
+        $group->getDefaultLocale()->willReturn(null);
+
+        $translation = null;
+        if (null !== $name) {
+            $translationProphecy = $this->prophesize(AttributeGroupTranslationInterface::class);
+            $translationProphecy->getName()->willReturn($name);
+            $translation = $translationProphecy->reveal();
+        }
+
+        $group->getTranslation('en')->willReturn($translation);
 
         return $group->reveal();
     }
@@ -163,6 +176,7 @@ class ProductAttributeFormMetadataVisitorTest extends TestCase
         self::assertArrayHasKey('attribute_group_1', $items);
         $section = $items['attribute_group_1'];
         self::assertInstanceOf(SectionMetadata::class, $section);
+        self::assertSame('Dimensions', $section->getLabel('en'));
         $sectionItems = $section->getItems();
         self::assertArrayHasKey('attributes/7', $sectionItems);
         $field = $sectionItems['attributes/7'];
@@ -172,6 +186,99 @@ class ProductAttributeFormMetadataVisitorTest extends TestCase
         self::assertSame('Weight in kilograms', $field->getDescription('en'));
         self::assertTrue($field->isRequired());
         self::assertFalse($form->isCacheable());
+    }
+
+    /**
+     * @return iterable<string, array{0: string|null}>
+     */
+    public static function provideMissingGroupNames(): iterable
+    {
+        yield 'no translation for locale' => [null];
+        yield 'empty translated name' => [''];
+    }
+
+    #[DataProvider('provideMissingGroupNames')]
+    public function testUsesGenericSectionLabelWhenGroupNameMissing(?string $groupName): void
+    {
+        $translation = $this->prophesize(AttributeTranslationInterface::class);
+        $translation->getName()->willReturn('Weight');
+        $translation->getDescription()->willReturn(null);
+
+        $attribute = $this->prophesize(AttributeInterface::class);
+        $attribute->getId()->willReturn(7);
+        $attribute->getKey()->willReturn('weight');
+        $attribute->getType()->willReturn(AttributeInterface::TYPE_NUMBER);
+        $attribute->getConfig()->willReturn([]);
+        $attribute->getTranslation('en')->willReturn($translation->reveal());
+        $attribute->getGroup()->willReturn($this->group(9, $groupName));
+
+        $familyAttribute = $this->prophesize(ProductFamilyAttributeInterface::class);
+        $familyAttribute->getAttribute()->willReturn($attribute->reveal());
+        $familyAttribute->isRequired()->willReturn(false);
+
+        $family = $this->prophesize(ProductFamilyInterface::class);
+        $family->getFamilyAttributes()->willReturn([$familyAttribute->reveal()]);
+
+        $this->productFamilyRepository->findOneBy(['productUuid' => 'uuid-1'])->willReturn($family->reveal());
+        $this->formMetadataLoader->getMetadata('product_attribute_number', 'en', [])
+            ->willReturn($this->fragmentWithValueField());
+
+        $form = new FormMetadata();
+        $form->setKey('product_details');
+
+        $this->visitor()->visitFormMetadata($form, 'en', ['id' => 'uuid-1']);
+
+        $items = $form->getItems();
+        self::assertArrayHasKey('attribute_group_9', $items);
+        $section = $items['attribute_group_9'];
+        self::assertInstanceOf(SectionMetadata::class, $section);
+        self::assertSame('Attributes', $section->getLabel('en'));
+    }
+
+    public function testUsesDefaultLocaleGroupNameWhenLocaleTranslationMissing(): void
+    {
+        $translation = $this->prophesize(AttributeTranslationInterface::class);
+        $translation->getName()->willReturn('Weight');
+        $translation->getDescription()->willReturn(null);
+
+        $groupTranslation = $this->prophesize(AttributeGroupTranslationInterface::class);
+        $groupTranslation->getName()->willReturn('Abmessungen');
+
+        $group = $this->prophesize(AttributeGroupInterface::class);
+        $group->getId()->willReturn(3);
+        $group->getTranslation('en')->willReturn(null);
+        $group->getDefaultLocale()->willReturn('de');
+        $group->getTranslation('de')->willReturn($groupTranslation->reveal());
+
+        $attribute = $this->prophesize(AttributeInterface::class);
+        $attribute->getId()->willReturn(7);
+        $attribute->getKey()->willReturn('weight');
+        $attribute->getType()->willReturn(AttributeInterface::TYPE_NUMBER);
+        $attribute->getConfig()->willReturn([]);
+        $attribute->getTranslation('en')->willReturn($translation->reveal());
+        $attribute->getGroup()->willReturn($group->reveal());
+
+        $familyAttribute = $this->prophesize(ProductFamilyAttributeInterface::class);
+        $familyAttribute->getAttribute()->willReturn($attribute->reveal());
+        $familyAttribute->isRequired()->willReturn(false);
+
+        $family = $this->prophesize(ProductFamilyInterface::class);
+        $family->getFamilyAttributes()->willReturn([$familyAttribute->reveal()]);
+
+        $this->productFamilyRepository->findOneBy(['productUuid' => 'uuid-1'])->willReturn($family->reveal());
+        $this->formMetadataLoader->getMetadata('product_attribute_number', 'en', [])
+            ->willReturn($this->fragmentWithValueField());
+
+        $form = new FormMetadata();
+        $form->setKey('product_details');
+
+        $this->visitor()->visitFormMetadata($form, 'en', ['id' => 'uuid-1']);
+
+        $items = $form->getItems();
+        self::assertArrayHasKey('attribute_group_3', $items);
+        $section = $items['attribute_group_3'];
+        self::assertInstanceOf(SectionMetadata::class, $section);
+        self::assertSame('Abmessungen', $section->getLabel('en'));
     }
 
     public function testInjectsValidationSchemaForAttributes(): void

--- a/tests/Unit/Infrastructure/Sulu/Admin/ProductVariantAttributeFormMetadataVisitorTest.php
+++ b/tests/Unit/Infrastructure/Sulu/Admin/ProductVariantAttributeFormMetadataVisitorTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sulu\Product\Tests\Unit\Infrastructure\Sulu\Admin;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
@@ -61,7 +62,12 @@ class ProductVariantAttributeFormMetadataVisitorTest extends TestCase
         $mapperContainer->set('number', new NumberPropertyMetadataMapper());
 
         $translator = $this->createStub(TranslatorInterface::class);
-        $translator->method('trans')->willReturn('Unit');
+        $translator->method('trans')->willReturnCallback(
+            static fn (string $id): string => match ($id) {
+                'sulu_product.attributes' => 'Attributes',
+                default => 'Unit',
+            },
+        );
 
         return new ProductVariantAttributeFormMetadataVisitor(
             $this->productFamilyRepository->reveal(),
@@ -72,17 +78,24 @@ class ProductVariantAttributeFormMetadataVisitorTest extends TestCase
                 $translator,
             ),
             new PropertyMetadataMapperRegistry($mapperContainer),
+            $translator,
         );
     }
 
-    private function group(int $id = 1, string $name = 'Color'): AttributeGroupInterface
+    private function group(int $id = 1, ?string $name = 'Color'): AttributeGroupInterface
     {
-        $translation = $this->prophesize(AttributeGroupTranslationInterface::class);
-        $translation->getName()->willReturn($name);
-
         $group = $this->prophesize(AttributeGroupInterface::class);
         $group->getId()->willReturn($id);
-        $group->getTranslation('en')->willReturn($translation->reveal());
+        $group->getDefaultLocale()->willReturn(null);
+
+        $translation = null;
+        if (null !== $name) {
+            $translationProphecy = $this->prophesize(AttributeGroupTranslationInterface::class);
+            $translationProphecy->getName()->willReturn($name);
+            $translation = $translationProphecy->reveal();
+        }
+
+        $group->getTranslation('en')->willReturn($translation);
 
         return $group->reveal();
     }
@@ -103,7 +116,7 @@ class ProductVariantAttributeFormMetadataVisitorTest extends TestCase
     /**
      * @return array{0: ObjectProphecy<AttributeInterface>, 1: ObjectProphecy<ProductFamilyAttributeInterface>}
      */
-    private function attributeWithFamilyAttribute(int $id, string $key, string $name, bool $variant, bool $required = false): array
+    private function attributeWithFamilyAttribute(int $id, string $key, string $name, bool $variant, bool $required = false, ?AttributeGroupInterface $group = null): array
     {
         $translation = $this->prophesize(AttributeTranslationInterface::class);
         $translation->getName()->willReturn($name);
@@ -115,7 +128,7 @@ class ProductVariantAttributeFormMetadataVisitorTest extends TestCase
         $attribute->getType()->willReturn(AttributeInterface::TYPE_NUMBER);
         $attribute->getConfig()->willReturn([]);
         $attribute->getTranslation('en')->willReturn($translation->reveal());
-        $attribute->getGroup()->willReturn($this->group());
+        $attribute->getGroup()->willReturn($group ?? $this->group());
 
         $familyAttribute = $this->prophesize(ProductFamilyAttributeInterface::class);
         $familyAttribute->getAttribute()->willReturn($attribute->reveal());
@@ -181,6 +194,7 @@ class ProductVariantAttributeFormMetadataVisitorTest extends TestCase
         self::assertArrayHasKey('attribute_group_1', $items);
         $section = $items['attribute_group_1'];
         self::assertInstanceOf(SectionMetadata::class, $section);
+        self::assertSame('Color', $section->getLabel('en'));
         $sectionItems = $section->getItems();
 
         self::assertArrayHasKey('attributes/7', $sectionItems);
@@ -191,6 +205,71 @@ class ProductVariantAttributeFormMetadataVisitorTest extends TestCase
         self::assertArrayNotHasKey('attributes/8', $sectionItems);
 
         self::assertFalse($form->isCacheable());
+    }
+
+    /**
+     * @return iterable<string, array{0: string|null}>
+     */
+    public static function provideMissingGroupNames(): iterable
+    {
+        yield 'no translation for locale' => [null];
+        yield 'empty translated name' => [''];
+    }
+
+    #[DataProvider('provideMissingGroupNames')]
+    public function testUsesGenericSectionLabelWhenGroupNameMissing(?string $groupName): void
+    {
+        [, $familyAttribute] = $this->attributeWithFamilyAttribute(7, 'color', 'Color', true, false, $this->group(9, $groupName));
+
+        $family = $this->prophesize(ProductFamilyInterface::class);
+        $family->getFamilyAttributes()->willReturn([$familyAttribute->reveal()]);
+
+        $this->productFamilyRepository->findOneBy(['productUuid' => 'parent-1'])->willReturn($family->reveal());
+        $this->formMetadataLoader->getMetadata('product_attribute_number', 'en', [])
+            ->willReturn($this->fragmentWithValueField());
+
+        $form = new FormMetadata();
+        $form->setKey('product_variant');
+
+        $this->visitor()->visitFormMetadata($form, 'en', ['parentId' => 'parent-1']);
+
+        $items = $form->getItems();
+        self::assertArrayHasKey('attribute_group_9', $items);
+        $section = $items['attribute_group_9'];
+        self::assertInstanceOf(SectionMetadata::class, $section);
+        self::assertSame('Attributes', $section->getLabel('en'));
+    }
+
+    public function testUsesDefaultLocaleGroupNameWhenLocaleTranslationMissing(): void
+    {
+        $groupTranslation = $this->prophesize(AttributeGroupTranslationInterface::class);
+        $groupTranslation->getName()->willReturn('Farbe');
+
+        $group = $this->prophesize(AttributeGroupInterface::class);
+        $group->getId()->willReturn(3);
+        $group->getTranslation('en')->willReturn(null);
+        $group->getDefaultLocale()->willReturn('de');
+        $group->getTranslation('de')->willReturn($groupTranslation->reveal());
+
+        [, $familyAttribute] = $this->attributeWithFamilyAttribute(7, 'color', 'Color', true, false, $group->reveal());
+
+        $family = $this->prophesize(ProductFamilyInterface::class);
+        $family->getFamilyAttributes()->willReturn([$familyAttribute->reveal()]);
+
+        $this->productFamilyRepository->findOneBy(['productUuid' => 'parent-1'])->willReturn($family->reveal());
+        $this->formMetadataLoader->getMetadata('product_attribute_number', 'en', [])
+            ->willReturn($this->fragmentWithValueField());
+
+        $form = new FormMetadata();
+        $form->setKey('product_variant');
+
+        $this->visitor()->visitFormMetadata($form, 'en', ['parentId' => 'parent-1']);
+
+        $items = $form->getItems();
+        self::assertArrayHasKey('attribute_group_3', $items);
+        $section = $items['attribute_group_3'];
+        self::assertInstanceOf(SectionMetadata::class, $section);
+        self::assertSame('Farbe', $section->getLabel('en'));
     }
 
     public function testSkipsVariantAttributeWhenFieldCannotBeBuilt(): void

--- a/tests/Unit/Infrastructure/Sulu/Admin/ProductVariantAttributeFormMetadataVisitorTest.php
+++ b/tests/Unit/Infrastructure/Sulu/Admin/ProductVariantAttributeFormMetadataVisitorTest.php
@@ -26,6 +26,8 @@ use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMapperRegist
 use Sulu\Product\Application\AttributeType\AttributeTypeRegistry;
 use Sulu\Product\Application\AttributeType\NumberAttributeType;
 use Sulu\Product\Domain\Measurement\MeasurementRegistry;
+use Sulu\Product\Domain\Model\AttributeGroupInterface;
+use Sulu\Product\Domain\Model\AttributeGroupTranslationInterface;
 use Sulu\Product\Domain\Model\AttributeInterface;
 use Sulu\Product\Domain\Model\AttributeTranslationInterface;
 use Sulu\Product\Domain\Model\ProductFamilyAttributeInterface;
@@ -70,8 +72,19 @@ class ProductVariantAttributeFormMetadataVisitorTest extends TestCase
                 $translator,
             ),
             new PropertyMetadataMapperRegistry($mapperContainer),
-            $translator,
         );
+    }
+
+    private function group(int $id = 1, string $name = 'Color'): AttributeGroupInterface
+    {
+        $translation = $this->prophesize(AttributeGroupTranslationInterface::class);
+        $translation->getName()->willReturn($name);
+
+        $group = $this->prophesize(AttributeGroupInterface::class);
+        $group->getId()->willReturn($id);
+        $group->getTranslation('en')->willReturn($translation->reveal());
+
+        return $group->reveal();
     }
 
     private function fragmentWithValueField(): FormMetadata
@@ -102,6 +115,7 @@ class ProductVariantAttributeFormMetadataVisitorTest extends TestCase
         $attribute->getType()->willReturn(AttributeInterface::TYPE_NUMBER);
         $attribute->getConfig()->willReturn([]);
         $attribute->getTranslation('en')->willReturn($translation->reveal());
+        $attribute->getGroup()->willReturn($this->group());
 
         $familyAttribute = $this->prophesize(ProductFamilyAttributeInterface::class);
         $familyAttribute->getAttribute()->willReturn($attribute->reveal());
@@ -164,8 +178,8 @@ class ProductVariantAttributeFormMetadataVisitorTest extends TestCase
         $this->visitor()->visitFormMetadata($form, 'en', ['parentId' => 'parent-1']);
 
         $items = $form->getItems();
-        self::assertArrayHasKey('attributes', $items);
-        $section = $items['attributes'];
+        self::assertArrayHasKey('attribute_group_1', $items);
+        $section = $items['attribute_group_1'];
         self::assertInstanceOf(SectionMetadata::class, $section);
         $sectionItems = $section->getItems();
 
@@ -201,7 +215,7 @@ class ProductVariantAttributeFormMetadataVisitorTest extends TestCase
 
         $this->visitor()->visitFormMetadata($form, 'en', ['parentId' => 'parent-1']);
 
-        self::assertArrayNotHasKey('attributes', $form->getItems());
+        self::assertArrayNotHasKey('attribute_group_1', $form->getItems());
     }
 
     public function testAddsUnitFieldForVariantAttributeWithUnit(): void
@@ -216,6 +230,7 @@ class ProductVariantAttributeFormMetadataVisitorTest extends TestCase
         $attribute->getType()->willReturn(AttributeInterface::TYPE_NUMBER);
         $attribute->getConfig()->willReturn(['unit' => 'GRAM']);
         $attribute->getTranslation('en')->willReturn($translation->reveal());
+        $attribute->getGroup()->willReturn($this->group());
 
         $familyAttribute = $this->prophesize(ProductFamilyAttributeInterface::class);
         $familyAttribute->getAttribute()->willReturn($attribute->reveal());
@@ -235,8 +250,8 @@ class ProductVariantAttributeFormMetadataVisitorTest extends TestCase
         $this->visitor()->visitFormMetadata($form, 'en', ['parentId' => 'parent-1']);
 
         $items = $form->getItems();
-        self::assertArrayHasKey('attributes', $items);
-        $section = $items['attributes'];
+        self::assertArrayHasKey('attribute_group_1', $items);
+        $section = $items['attribute_group_1'];
         self::assertInstanceOf(SectionMetadata::class, $section);
         $sectionItems = $section->getItems();
 
@@ -256,6 +271,7 @@ class ProductVariantAttributeFormMetadataVisitorTest extends TestCase
         $attribute->getType()->willReturn(AttributeInterface::TYPE_NUMBER);
         $attribute->getConfig()->willReturn([]);
         $attribute->getTranslation('en')->willReturn($translation->reveal());
+        $attribute->getGroup()->willReturn($this->group());
 
         $familyAttribute = $this->prophesize(ProductFamilyAttributeInterface::class);
         $familyAttribute->getAttribute()->willReturn($attribute->reveal());
@@ -284,10 +300,74 @@ class ProductVariantAttributeFormMetadataVisitorTest extends TestCase
         $this->visitor()->visitFormMetadata($form, 'en', ['parentId' => 'parent-1']);
 
         $items = $form->getItems();
-        self::assertArrayHasKey('attributes', $items);
-        $section = $items['attributes'];
+        self::assertArrayHasKey('attribute_group_1', $items);
+        $section = $items['attribute_group_1'];
         self::assertInstanceOf(SectionMetadata::class, $section);
         self::assertArrayHasKey('attributes/13', $section->getItems());
         self::assertFalse($form->isCacheable());
+    }
+
+    public function testGroupsVariantAttributesIntoSeparateSectionsPerGroup(): void
+    {
+        $translation7 = $this->prophesize(AttributeTranslationInterface::class);
+        $translation7->getName()->willReturn('Color');
+        $translation7->getDescription()->willReturn(null);
+
+        $attribute7 = $this->prophesize(AttributeInterface::class);
+        $attribute7->getId()->willReturn(7);
+        $attribute7->getKey()->willReturn('color');
+        $attribute7->getType()->willReturn(AttributeInterface::TYPE_NUMBER);
+        $attribute7->getConfig()->willReturn([]);
+        $attribute7->getTranslation('en')->willReturn($translation7->reveal());
+        $attribute7->getGroup()->willReturn($this->group(1, 'Color'));
+
+        $familyAttribute7 = $this->prophesize(ProductFamilyAttributeInterface::class);
+        $familyAttribute7->getAttribute()->willReturn($attribute7->reveal());
+        $familyAttribute7->isRequired()->willReturn(false);
+        $familyAttribute7->isVariantSpecific()->willReturn(true);
+
+        $translation8 = $this->prophesize(AttributeTranslationInterface::class);
+        $translation8->getName()->willReturn('Size');
+        $translation8->getDescription()->willReturn(null);
+
+        $attribute8 = $this->prophesize(AttributeInterface::class);
+        $attribute8->getId()->willReturn(8);
+        $attribute8->getKey()->willReturn('size');
+        $attribute8->getType()->willReturn(AttributeInterface::TYPE_NUMBER);
+        $attribute8->getConfig()->willReturn([]);
+        $attribute8->getTranslation('en')->willReturn($translation8->reveal());
+        $attribute8->getGroup()->willReturn($this->group(2, 'Size'));
+
+        $familyAttribute8 = $this->prophesize(ProductFamilyAttributeInterface::class);
+        $familyAttribute8->getAttribute()->willReturn($attribute8->reveal());
+        $familyAttribute8->isRequired()->willReturn(false);
+        $familyAttribute8->isVariantSpecific()->willReturn(true);
+
+        $family = $this->prophesize(ProductFamilyInterface::class);
+        $family->getFamilyAttributes()->willReturn([
+            $familyAttribute7->reveal(),
+            $familyAttribute8->reveal(),
+        ]);
+
+        $this->productFamilyRepository->findOneBy(['productUuid' => 'parent-1'])->willReturn($family->reveal());
+        $this->formMetadataLoader->getMetadata('product_attribute_number', 'en', [])
+            ->willReturn($this->fragmentWithValueField());
+
+        $form = new FormMetadata();
+        $form->setKey('product_variant');
+
+        $this->visitor()->visitFormMetadata($form, 'en', ['parentId' => 'parent-1']);
+
+        $items = $form->getItems();
+        self::assertArrayHasKey('attribute_group_1', $items);
+        self::assertArrayHasKey('attribute_group_2', $items);
+
+        $sectionOne = $items['attribute_group_1'];
+        self::assertInstanceOf(SectionMetadata::class, $sectionOne);
+        self::assertArrayHasKey('attributes/7', $sectionOne->getItems());
+
+        $sectionTwo = $items['attribute_group_2'];
+        self::assertInstanceOf(SectionMetadata::class, $sectionTwo);
+        self::assertArrayHasKey('attributes/8', $sectionTwo->getItems());
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Both product attribute form metadata visitors now create one section per attribute group instead of a single combined attributes section. Each section is named after the group id and labeled with the group translation for the requested locale. When that translation is missing the group default locale is used instead. If no translation resolves at all the generic attributes label is kept as a fallback.

#### Why?

Product families can define many attributes which all ended up in one flat list in the admin form. Editors already organize attributes into groups so the form should reflect that same structure. Splitting the fields into sections per group makes long attribute forms easier to scan. The variant overlay form gets the same treatment so both forms stay consistent.