### PR TITLE
Fix required variant attributes and align product admin forms

### DIFF
--- a/config/forms/Product/product_details.xml
+++ b/config/forms/Product/product_details.xml
@@ -8,7 +8,7 @@
     <properties>
         <property name="title" type="text_line" mandatory="true" colspan="12">
             <meta>
-                <title>sulu_admin.title</title>
+                <title>sulu_admin.name</title>
             </meta>
 
             <params>

--- a/config/forms/Product/product_details.xml
+++ b/config/forms/Product/product_details.xml
@@ -6,7 +6,7 @@
     <key>product_details</key>
 
     <properties>
-        <property name="title" type="text_line" mandatory="true" colspan="9">
+        <property name="title" type="text_line" mandatory="true" colspan="12">
             <meta>
                 <title>sulu_admin.title</title>
             </meta>
@@ -16,7 +16,25 @@
             </params>
         </property>
 
-        <property name="type" type="single_select" mandatory="true" colspan="3" disabledCondition="!!id">
+        <property name="code" type="text_line" colspan="6">
+            <meta>
+                <title>sulu_product.code</title>
+            </meta>
+        </property>
+
+        <property name="status" type="single_select" colspan="6">
+            <meta>
+                <title>sulu_product.status</title>
+            </meta>
+        </property>
+
+        <property name="productFamily" type="single_product_family_selection" mandatory="true" colspan="6" disabledCondition="!!id" multilingual="false">
+            <meta>
+                <title>sulu_product.product_family</title>
+            </meta>
+        </property>
+
+        <property name="type" type="single_select" mandatory="true" colspan="6" disabledCondition="!!id">
             <meta>
                 <title>sulu_product.product_type</title>
             </meta>
@@ -38,33 +56,11 @@
             </params>
         </property>
 
-        <property name="code" type="text_line" colspan="3" visibleCondition="type != 'product_with_variants'">
-            <meta>
-                <title>sulu_product.code</title>
-            </meta>
-
-            <params>
-                <param name="headline" value="true"/>
-            </params>
-        </property>
-
-        <property name="externalIdentifier" type="text_line"
+        <property name="externalIdentifier" type="text_line" colspan="12"
                   visibleCondition="!!externalIdentifier"
                   disabledCondition="true">
             <meta>
                 <title>sulu_product.external_identifier</title>
-            </meta>
-        </property>
-
-        <property name="productFamily" type="single_product_family_selection" mandatory="true" colspan="6" disabledCondition="!!id" multilingual="false">
-            <meta>
-                <title>sulu_product.product_family</title>
-            </meta>
-        </property>
-
-        <property name="status" type="single_select" colspan="6">
-            <meta>
-                <title>sulu_product.status</title>
             </meta>
         </property>
 
@@ -74,24 +70,32 @@
             </meta>
         </property>
 
-        <property name="details/image" type="single_media_selection" multilingual="false">
+        <section name="media" colspan="12">
             <meta>
-                <title>sulu_product.image</title>
+                <title>sulu_product.media</title>
             </meta>
 
-            <params>
-                <param name="types" value="image"/>
-            </params>
-        </property>
+            <properties>
+                <property name="details/image" type="single_media_selection" colspan="12" multilingual="false">
+                    <meta>
+                        <title>sulu_product.image</title>
+                    </meta>
 
-        <property name="details/documents" type="media_selection" multilingual="false">
-            <meta>
-                <title>sulu_product.documents</title>
-            </meta>
+                    <params>
+                        <param name="types" value="image"/>
+                    </params>
+                </property>
 
-            <params>
-                <param name="types" value="document"/>
-            </params>
-        </property>
+                <property name="details/documents" type="media_selection" colspan="12" multilingual="false">
+                    <meta>
+                        <title>sulu_product.documents</title>
+                    </meta>
+
+                    <params>
+                        <param name="types" value="document"/>
+                    </params>
+                </property>
+            </properties>
+        </section>
     </properties>
 </form>

--- a/config/forms/Product/product_variant.xml
+++ b/config/forms/Product/product_variant.xml
@@ -6,10 +6,14 @@
     <key>product_variant</key>
 
     <properties>
-        <property name="title" type="text_line" colspan="6">
+        <property name="title" type="text_line" mandatory="true" colspan="12">
             <meta>
                 <title>sulu_admin.title</title>
             </meta>
+
+            <params>
+                <param name="headline" value="true"/>
+            </params>
         </property>
 
         <property name="code" type="text_line" mandatory="true" colspan="6">
@@ -24,30 +28,46 @@
             </meta>
         </property>
 
-        <property name="shortDescription" type="text_editor" colspan="12">
+        <property name="externalIdentifier" type="text_line" colspan="12"
+                  visibleCondition="!!externalIdentifier"
+                  disabledCondition="true">
+            <meta>
+                <title>sulu_product.external_identifier</title>
+            </meta>
+        </property>
+
+        <property name="details/shortDescription" type="text_editor" colspan="12">
             <meta>
                 <title>sulu_product.short_description</title>
             </meta>
         </property>
 
-        <property name="image" type="single_media_selection" colspan="6">
+        <section name="media" colspan="12">
             <meta>
-                <title>sulu_product.image</title>
+                <title>sulu_product.media</title>
             </meta>
 
-            <params>
-                <param name="types" value="image"/>
-            </params>
-        </property>
+            <properties>
+                <property name="details/image" type="single_media_selection" colspan="12" multilingual="false">
+                    <meta>
+                        <title>sulu_product.image</title>
+                    </meta>
 
-        <property name="documents" type="media_selection" colspan="6">
-            <meta>
-                <title>sulu_product.documents</title>
-            </meta>
+                    <params>
+                        <param name="types" value="image"/>
+                    </params>
+                </property>
 
-            <params>
-                <param name="types" value="document"/>
-            </params>
-        </property>
+                <property name="details/documents" type="media_selection" colspan="12" multilingual="false">
+                    <meta>
+                        <title>sulu_product.documents</title>
+                    </meta>
+
+                    <params>
+                        <param name="types" value="document"/>
+                    </params>
+                </property>
+            </properties>
+        </section>
     </properties>
 </form>

--- a/config/forms/Product/product_variant.xml
+++ b/config/forms/Product/product_variant.xml
@@ -8,7 +8,7 @@
     <properties>
         <property name="title" type="text_line" mandatory="true" colspan="12">
             <meta>
-                <title>sulu_admin.title</title>
+                <title>sulu_admin.name</title>
             </meta>
 
             <params>

--- a/config/lists/products.xml
+++ b/config/lists/products.xml
@@ -20,6 +20,14 @@
         </join>
     </joins>
 
+    <joins name="productFamily" ref="unlocalizedDimensionContent">
+        <join>
+            <entity-name>Sulu\Product\Domain\Model\ProductFamilyInterface</entity-name>
+            <field-name>unlocalizedDimensionContent.productFamily</field-name>
+            <method>LEFT</method>
+        </join>
+    </joins>
+
     <joins name="ghostDimensionContent" ref="unlocalizedDimensionContent">
         <join>
             <entity-name>ghostDimensionContent</entity-name>
@@ -90,6 +98,8 @@
                     <param name="prefix" value="sulu_product.product_status."/>
                 </params>
             </transformer>
+
+            <filter type="select"/>
         </property>
 
         <property name="type" translation="sulu_product.product_type" visibility="yes">
@@ -100,6 +110,29 @@
                     <param name="prefix" value="sulu_product.product_type_"/>
                 </params>
             </transformer>
+
+            <filter type="select">
+                <params>
+                    <param name="options" type="collection">
+                        <param name="product" value="sulu_product.product_type_product"/>
+                        <param name="product_with_variants" value="sulu_product.product_type_product_with_variants"/>
+                    </param>
+                </params>
+            </filter>
+        </property>
+
+        <property name="productFamily" translation="sulu_product.product_family" visibility="never">
+            <field-name>uuid</field-name>
+            <entity-name>Sulu\Product\Domain\Model\ProductFamilyInterface</entity-name>
+
+            <joins ref="productFamily"/>
+
+            <filter type="selection">
+                <params>
+                    <param name="displayProperty" value="name"/>
+                    <param name="resourceKey" value="product_families"/>
+                </params>
+            </filter>
         </property>
 
         <property name="created" translation="sulu_admin.created" visibility="no">
@@ -145,6 +178,23 @@
         <property name="locale" translation="sulu_admin.locale" visibility="never">
             <field-name>locale</field-name>
             <entity-name>dimensionContent</entity-name>
+        </property>
+
+        <property name="publishedState" translation="sulu_content.published_state" visibility="never">
+            <field-name>workflowPlace</field-name>
+            <entity-name>dimensionContent</entity-name>
+
+            <joins ref="dimensionContent"/>
+
+            <filter type="select">
+                <params>
+                    <param name="options" type="collection">
+                        <param name="published" value="sulu_content.state_published"/>
+                        <param name="unpublished" value="sulu_content.state_not_published"/>
+                        <param name="draft" value="sulu_admin.draft"/>
+                    </param>
+                </params>
+            </filter>
         </property>
 
         <property name="ghostLocale" translation="sulu_admin.ghost_locale" visibility="never">

--- a/src/Infrastructure/Sulu/Admin/ProductAdmin.php
+++ b/src/Infrastructure/Sulu/Admin/ProductAdmin.php
@@ -25,6 +25,7 @@ use Sulu\Component\Localization\Manager\LocalizationManagerInterface;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
 use Sulu\Product\Domain\Association\ProductAssociationTypeRegistry;
+use Sulu\Product\Domain\Model\ProductDimensionContentInterface;
 use Sulu\Product\Domain\Model\ProductInterface;
 
 /**
@@ -182,8 +183,11 @@ class ProductAdmin extends Admin
             );
         }
         $viewCollection->add(
-            $this->viewBuilderFactory->createFormViewBuilder(static::EDIT_TABS_VIEW . '.details', '/details')
+            $this->viewBuilderFactory->createPreviewFormViewBuilder(static::EDIT_TABS_VIEW . '.details', '/details')
                 ->setResourceKey(ProductInterface::RESOURCE_KEY)
+                // the preview object provider is registered for the dimension content, not the product
+                ->setPreviewResourceKey(ProductDimensionContentInterface::RESOURCE_KEY)
+                ->setPreviewCondition('workflowPlace != null')
                 ->setFormKey(ProductInterface::FORM_KEY)
                 ->setTabTitle('sulu_admin.details')
                 ->setTabOrder(10)

--- a/src/Infrastructure/Sulu/Admin/ProductAdmin.php
+++ b/src/Infrastructure/Sulu/Admin/ProductAdmin.php
@@ -137,7 +137,7 @@ class ProductAdmin extends Admin
                 ->setResourceKey(ProductInterface::RESOURCE_KEY)
                 ->addLocales($locales)
                 ->setBackView(static::LIST_VIEW)
-                ->setTitleProperty('name'),
+                ->setTitleProperty('title'),
         );
 
         // Details form — add mode
@@ -225,6 +225,7 @@ class ProductAdmin extends Admin
                     ->setResourceKey(ProductInterface::RESOURCE_KEY)
                     ->setFormKey('product_associations')
                     ->setTabTitle('sulu_product.associations')
+                    ->setTitleVisible(true)
                     ->setTabOrder(30)
                     ->addRouterAttributesToFormMetadata(['id'])
                     ->addToolbarActions($editToolbarActions)

--- a/src/Infrastructure/Sulu/Admin/ProductAttributeFormMetadataVisitor.php
+++ b/src/Infrastructure/Sulu/Admin/ProductAttributeFormMetadataVisitor.php
@@ -20,9 +20,7 @@ use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMapperRegistry;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SchemaMetadata;
 use Sulu\Product\Domain\Model\AttributeGroupInterface;
-use Sulu\Product\Domain\Model\ProductInterface;
 use Sulu\Product\Domain\Repository\ProductFamilyRepositoryInterface;
-use Sulu\Product\Domain\Repository\ProductRepositoryInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -37,7 +35,6 @@ class ProductAttributeFormMetadataVisitor implements FormMetadataVisitorInterfac
         private readonly AttributeFieldFactory $attributeFieldFactory,
         private readonly PropertyMetadataMapperRegistry $propertyMetadataMapperRegistry,
         private readonly TranslatorInterface $translator,
-        private readonly ProductRepositoryInterface $productRepository,
     ) {
     }
 
@@ -58,9 +55,6 @@ class ProductAttributeFormMetadataVisitor implements FormMetadataVisitorInterfac
             return;
         }
 
-        $product = $this->productRepository->findOneBy(['uuid' => $id]);
-        $isProductWithVariants = $product?->isType(ProductInterface::TYPE_PRODUCT_WITH_VARIANTS) ?? false;
-
         $items = $formMetadata->getItems();
 
         /** @var array<int, SectionMetadata> $sections */
@@ -69,7 +63,8 @@ class ProductAttributeFormMetadataVisitor implements FormMetadataVisitorInterfac
         $schemaProperties = [];
 
         foreach ($family->getFamilyAttributes() as $familyAttribute) {
-            if ($isProductWithVariants && $familyAttribute->isVariantSpecific()) {
+            if ($familyAttribute->isVariantSpecific()) {
+                // variant axes live on the variant overlay, never on a product
                 continue;
             }
 

--- a/src/Infrastructure/Sulu/Admin/ProductCodeFormMetadataVisitor.php
+++ b/src/Infrastructure/Sulu/Admin/ProductCodeFormMetadataVisitor.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Product\Infrastructure\Sulu\Admin;
+
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadataVisitorInterface;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\ConstMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SchemaMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\StringMetadata;
+use Sulu\Product\Domain\Model\ProductInterface;
+
+/**
+ * A plain product must carry a code, a product with variants may leave it empty — the variants
+ * carry their own. Expressed as a schema branch on `type` instead of `mandatory="true"` so it
+ * follows the type select live, and with a non-empty string constraint because a bare `required`
+ * would accept the `null` that a code-less product loads with.
+ *
+ * @internal
+ */
+class ProductCodeFormMetadataVisitor implements FormMetadataVisitorInterface
+{
+    private const FORM_KEY = 'product_details';
+
+    public function visitFormMetadata(FormMetadata $formMetadata, string $locale, array $metadataOptions = []): void
+    {
+        if (self::FORM_KEY !== $formMetadata->getKey()) {
+            return;
+        }
+
+        $formMetadata->setSchema($formMetadata->getSchema()->merge(new SchemaMetadata([], [
+            new SchemaMetadata([
+                new PropertyMetadata('type', false, new ConstMetadata(ProductInterface::TYPE_PRODUCT_WITH_VARIANTS)),
+            ]),
+            new SchemaMetadata([
+                new PropertyMetadata('type', false, new ConstMetadata(ProductInterface::TYPE_PRODUCT)),
+                new PropertyMetadata('code', true, new StringMetadata(1)),
+            ]),
+        ])));
+    }
+}

--- a/src/Infrastructure/Sulu/Admin/ProductCodeFormMetadataVisitor.php
+++ b/src/Infrastructure/Sulu/Admin/ProductCodeFormMetadataVisitor.php
@@ -22,10 +22,9 @@ use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\StringMetadata;
 use Sulu\Product\Domain\Model\ProductInterface;
 
 /**
- * A plain product must carry a code, a product with variants may leave it empty — the variants
- * carry their own. Expressed as a schema branch on `type` instead of `mandatory="true"` so it
- * follows the type select live, and with a non-empty string constraint because a bare `required`
- * would accept the `null` that a code-less product loads with.
+ * Requires a code on plain products only, as a schema branch so it follows the type select live.
+ * The length constraint is needed because a bare `required` accepts the `null` a code-less
+ * product loads with.
  *
  * @internal
  */

--- a/src/Infrastructure/Sulu/Admin/ProductContentAdmin.php
+++ b/src/Infrastructure/Sulu/Admin/ProductContentAdmin.php
@@ -14,7 +14,9 @@ declare(strict_types=1);
 namespace Sulu\Product\Infrastructure\Sulu\Admin;
 
 use Sulu\Bundle\AdminBundle\Admin\Admin;
+use Sulu\Bundle\AdminBundle\Admin\View\FormViewBuilderInterface;
 use Sulu\Bundle\AdminBundle\Admin\View\PreviewFormViewBuilderInterface;
+use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderInterface;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
@@ -28,6 +30,13 @@ use Sulu\Product\Domain\Model\ProductInterface;
  */
 class ProductContentAdmin extends Admin
 {
+    private const TAB_ORDERS = [
+        ProductAdmin::EDIT_TABS_VIEW . '.content' => 40,
+        ProductAdmin::EDIT_TABS_VIEW . '.seo' => 50,
+        ProductAdmin::EDIT_TABS_VIEW . '.excerpt' => 60,
+        ProductAdmin::EDIT_TABS_VIEW . '.settings' => 70,
+    ];
+
     public function __construct(
         private ContentViewBuilderFactoryInterface $contentViewBuilderFactory,
         private SecurityCheckerInterface $securityChecker,
@@ -54,7 +63,27 @@ class ProductContentAdmin extends Admin
             if ($viewBuilder instanceof PreviewFormViewBuilderInterface) {
                 $viewBuilder->setPreviewCondition('workflowPlace != null');
             }
+
+            $this->applyTabOrder($viewBuilder);
+
             $viewCollection->add($viewBuilder);
+        }
+    }
+
+    /**
+     * The content views default to tab orders that collide with the product's own tabs, so they are
+     * pushed behind details (10), variants (20) and associations (30).
+     */
+    private function applyTabOrder(ViewBuilderInterface $viewBuilder): void
+    {
+        $tabOrder = self::TAB_ORDERS[$viewBuilder->getName()] ?? null;
+
+        if (null === $tabOrder) {
+            return;
+        }
+
+        if ($viewBuilder instanceof PreviewFormViewBuilderInterface || $viewBuilder instanceof FormViewBuilderInterface) {
+            $viewBuilder->setTabOrder($tabOrder);
         }
     }
 

--- a/src/Infrastructure/Sulu/Admin/ProductContentAdmin.php
+++ b/src/Infrastructure/Sulu/Admin/ProductContentAdmin.php
@@ -71,8 +71,8 @@ class ProductContentAdmin extends Admin
     }
 
     /**
-     * The content views default to tab orders that collide with the product's own tabs, so they are
-     * pushed behind details (10), variants (20) and associations (30).
+     * The content views default to orders that collide with details (10), variants (20) and
+     * associations (30).
      */
     private function applyTabOrder(ViewBuilderInterface $viewBuilder): void
     {

--- a/src/Infrastructure/Sulu/Admin/ProductsListMetadataVisitor.php
+++ b/src/Infrastructure/Sulu/Admin/ProductsListMetadataVisitor.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Product\Infrastructure\Sulu\Admin;
+
+use Sulu\Bundle\AdminBundle\Metadata\ListMetadata\ListMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\ListMetadata\ListMetadataVisitorInterface;
+use Sulu\Product\Domain\Model\ProductInterface;
+
+/**
+ * Fills the status filter options from the configured product statuses, the same source
+ * {@see ProductStatusFormMetadataVisitor} uses for the form's status select — they cannot be
+ * hardcoded in the list XML because projects can configure their own statuses.
+ *
+ * @internal
+ */
+class ProductsListMetadataVisitor implements ListMetadataVisitorInterface
+{
+    private const LIST_KEY = ProductInterface::LIST_KEY;
+
+    /**
+     * @param array<int, string> $productStatuses
+     */
+    public function __construct(
+        private readonly array $productStatuses,
+    ) {
+    }
+
+    public function visitListMetadata(ListMetadata $listMetadata, string $key, string $locale, array $metadataOptions = []): void
+    {
+        if (self::LIST_KEY !== $key) {
+            return;
+        }
+
+        $statusField = $listMetadata->getField('status');
+
+        $options = [];
+        foreach ($this->productStatuses as $status) {
+            $options[$status] = 'sulu_product.product_status.' . $status;
+        }
+
+        $statusField->setFilterTypeParameters(['options' => $options]);
+    }
+}

--- a/src/Infrastructure/Sulu/Admin/ProductsListMetadataVisitor.php
+++ b/src/Infrastructure/Sulu/Admin/ProductsListMetadataVisitor.php
@@ -18,9 +18,8 @@ use Sulu\Bundle\AdminBundle\Metadata\ListMetadata\ListMetadataVisitorInterface;
 use Sulu\Product\Domain\Model\ProductInterface;
 
 /**
- * Fills the status filter options from the configured product statuses, the same source
- * {@see ProductStatusFormMetadataVisitor} uses for the form's status select — they cannot be
- * hardcoded in the list XML because projects can configure their own statuses.
+ * Fills the status filter options from the configured statuses, which cannot be hardcoded in the
+ * list XML because projects can configure their own.
  *
  * @internal
  */

--- a/src/Infrastructure/Sulu/Content/DataMapper/ProductAttributesDataMapper.php
+++ b/src/Infrastructure/Sulu/Content/DataMapper/ProductAttributesDataMapper.php
@@ -130,8 +130,9 @@ class ProductAttributesDataMapper implements DataMapperInterface
                 continue;
             }
 
-            if ($isVariant && !$familyAttribute->isVariantSpecific()) {
-                // Shared attributes are inherited from (and required on) the parent, not the variant.
+            if ($familyAttribute->isVariantSpecific() !== $isVariant) {
+                // Variant axes are required on the variant, shared attributes on the product:
+                // neither side can satisfy a requirement whose field the other side owns.
                 continue;
             }
 

--- a/src/Infrastructure/Sulu/Content/DataMapper/ProductAttributesDataMapper.php
+++ b/src/Infrastructure/Sulu/Content/DataMapper/ProductAttributesDataMapper.php
@@ -131,8 +131,7 @@ class ProductAttributesDataMapper implements DataMapperInterface
             }
 
             if ($familyAttribute->isVariantSpecific() !== $isVariant) {
-                // Variant axes are required on the variant, shared attributes on the product:
-                // neither side can satisfy a requirement whose field the other side owns.
+                // variant axes are required on the variant, shared attributes on the product
                 continue;
             }
 

--- a/src/Infrastructure/Symfony/HttpKernel/SuluProductBundle.php
+++ b/src/Infrastructure/Symfony/HttpKernel/SuluProductBundle.php
@@ -103,6 +103,7 @@ use Sulu\Product\Infrastructure\Sulu\Admin\ProductAdmin;
 use Sulu\Product\Infrastructure\Sulu\Admin\ProductAssociationsFieldMetadataValidator;
 use Sulu\Product\Infrastructure\Sulu\Admin\ProductAssociationsFormMetadataVisitor;
 use Sulu\Product\Infrastructure\Sulu\Admin\ProductAttributeFormMetadataVisitor;
+use Sulu\Product\Infrastructure\Sulu\Admin\ProductCodeFormMetadataVisitor;
 use Sulu\Product\Infrastructure\Sulu\Admin\ProductContentAdmin;
 use Sulu\Product\Infrastructure\Sulu\Admin\ProductContentFormMetadataVisitor;
 use Sulu\Product\Infrastructure\Sulu\Admin\ProductFamilyAdmin;
@@ -831,7 +832,6 @@ final class SuluProductBundle extends AbstractBundle
                 new Reference('sulu_product.attribute_field_factory'),
                 new Reference('sulu_admin.property_metadata_mapper_registry'),
                 new Reference('translator'),
-                new Reference('sulu_product.product_repository'),
             ])
             ->tag('sulu_admin.form_metadata_visitor');
 
@@ -864,6 +864,10 @@ final class SuluProductBundle extends AbstractBundle
         $services->set('sulu_product.product_content_form_metadata_visitor')
             ->class(ProductContentFormMetadataVisitor::class)
             ->tag('sulu_admin.typed_form_metadata_visitor');
+
+        $services->set('sulu_product.product_code_form_metadata_visitor')
+            ->class(ProductCodeFormMetadataVisitor::class)
+            ->tag('sulu_admin.form_metadata_visitor');
 
         $services->set('sulu_product.product_status_form_metadata_visitor')
             ->class(ProductStatusFormMetadataVisitor::class)

--- a/src/Infrastructure/Symfony/HttpKernel/SuluProductBundle.php
+++ b/src/Infrastructure/Symfony/HttpKernel/SuluProductBundle.php
@@ -108,6 +108,7 @@ use Sulu\Product\Infrastructure\Sulu\Admin\ProductContentAdmin;
 use Sulu\Product\Infrastructure\Sulu\Admin\ProductContentFormMetadataVisitor;
 use Sulu\Product\Infrastructure\Sulu\Admin\ProductFamilyAdmin;
 use Sulu\Product\Infrastructure\Sulu\Admin\ProductFamilyFormMetadataVisitor;
+use Sulu\Product\Infrastructure\Sulu\Admin\ProductsListMetadataVisitor;
 use Sulu\Product\Infrastructure\Sulu\Admin\ProductStatusFormMetadataVisitor;
 use Sulu\Product\Infrastructure\Sulu\Admin\ProductVariantAttributeFormMetadataVisitor;
 use Sulu\Product\Infrastructure\Sulu\Content\DataMapper\AdditionalWebspacesDataMapper;
@@ -868,6 +869,13 @@ final class SuluProductBundle extends AbstractBundle
         $services->set('sulu_product.product_code_form_metadata_visitor')
             ->class(ProductCodeFormMetadataVisitor::class)
             ->tag('sulu_admin.form_metadata_visitor');
+
+        $services->set('sulu_product.products_list_metadata_visitor')
+            ->class(ProductsListMetadataVisitor::class)
+            ->args([
+                '%sulu_product.product_statuses%',
+            ])
+            ->tag('sulu_admin.list_metadata_visitor');
 
         $services->set('sulu_product.product_status_form_metadata_visitor')
             ->class(ProductStatusFormMetadataVisitor::class)

--- a/src/Infrastructure/Symfony/HttpKernel/SuluProductBundle.php
+++ b/src/Infrastructure/Symfony/HttpKernel/SuluProductBundle.php
@@ -1288,7 +1288,8 @@ final class SuluProductBundle extends AbstractBundle
                                     'list_overlay' => [
                                         'adapter' => 'table',
                                         'list_key' => 'products',
-                                        'display_properties' => ['name'],
+                                        // the selected item is loaded from the detail endpoint, which has no `name`
+                                        'display_properties' => ['title'],
                                         'empty_text' => 'sulu_product.no_product_selected',
                                         'icon' => 'su-newspaper',
                                         'overlay_title' => 'sulu_product.single_selection_overlay_title',

--- a/tests/Functional/HttpKernel/ProductDetailsFormSchemaTest.php
+++ b/tests/Functional/HttpKernel/ProductDetailsFormSchemaTest.php
@@ -20,10 +20,6 @@ use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadataProvider;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Product\Infrastructure\Sulu\Admin\ProductCodeFormMetadataVisitor;
 
-/**
- * Covers that the visitor is wired up and reaches the real product form; the exact shape of the
- * branch is asserted in the visitor's unit test.
- */
 #[CoversClass(ProductCodeFormMetadataVisitor::class)]
 class ProductDetailsFormSchemaTest extends SuluTestCase
 {

--- a/tests/Functional/HttpKernel/ProductDetailsFormSchemaTest.php
+++ b/tests/Functional/HttpKernel/ProductDetailsFormSchemaTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Product\Tests\Functional\HttpKernel;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadataProvider;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Product\Infrastructure\Sulu\Admin\ProductCodeFormMetadataVisitor;
+
+/**
+ * Covers that the visitor is wired up and reaches the real product form; the exact shape of the
+ * branch is asserted in the visitor's unit test.
+ */
+#[CoversClass(ProductCodeFormMetadataVisitor::class)]
+class ProductDetailsFormSchemaTest extends SuluTestCase
+{
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        \restore_exception_handler();
+    }
+
+    public function testCodeRequirementIsBranchedOnProductType(): void
+    {
+        self::bootKernel();
+
+        /** @var FormMetadataProvider $provider */
+        $provider = self::getContainer()->get('sulu_admin.form_metadata_provider');
+
+        $metadata = $provider->getMetadata('product_details', 'en');
+        $this->assertInstanceOf(FormMetadata::class, $metadata);
+
+        $schema = \json_encode($metadata->getSchema()->toJsonSchema());
+        $this->assertIsString($schema);
+
+        $this->assertStringContainsString(
+            '{"type":"object","properties":{"type":{"const":"product"},"code":{"type":"string","minLength":1}},"required":["code"]}',
+            $schema,
+        );
+        $this->assertStringContainsString(
+            '{"type":"object","properties":{"type":{"const":"product_with_variants"}}}',
+            $schema,
+        );
+    }
+
+    public function testCodeIsVisibleForEveryProductType(): void
+    {
+        self::bootKernel();
+
+        /** @var FormMetadataProvider $provider */
+        $provider = self::getContainer()->get('sulu_admin.form_metadata_provider');
+
+        $metadata = $provider->getMetadata('product_details', 'en');
+        $this->assertInstanceOf(FormMetadata::class, $metadata);
+
+        $code = $metadata->getItems()['code'] ?? null;
+        $this->assertInstanceOf(FieldMetadata::class, $code);
+        $this->assertNull($code->getVisibleCondition());
+    }
+}

--- a/tests/Functional/HttpKernel/ProductFieldTypeOptionsTest.php
+++ b/tests/Functional/HttpKernel/ProductFieldTypeOptionsTest.php
@@ -33,10 +33,11 @@ class ProductFieldTypeOptionsTest extends SuluTestCase
     }
 
     /**
-     * A selection renders the configured display properties of the referenced list, so a property the
-     * list does not provide leaves every selected item blank in the admin.
+     * A multi selection renders its items from the list endpoint, so a display property the list does
+     * not provide leaves every selected item blank in the admin. Single selections load the whole item
+     * from the detail endpoint instead and are covered by ProductControllerTest.
      */
-    public function testEverySelectionDisplayPropertyIsProvidedByItsList(): void
+    public function testEveryMultiSelectionDisplayPropertyIsProvidedByItsList(): void
     {
         self::bootKernel();
 
@@ -45,6 +46,10 @@ class ProductFieldTypeOptionsTest extends SuluTestCase
 
         $assertedProperties = 0;
         foreach ($this->getSelectionListOverlayTypes() as $fieldTypeName => $type) {
+            if (!\str_starts_with($fieldTypeName, 'selection.')) {
+                continue;
+            }
+
             $fieldDescriptors = $fieldDescriptorFactory->getFieldDescriptors($type['list_key']);
             $this->assertIsArray($fieldDescriptors, \sprintf('List "%s" of "%s" does not exist.', $type['list_key'], $fieldTypeName));
 

--- a/tests/Functional/HttpKernel/ProductVariantFormTest.php
+++ b/tests/Functional/HttpKernel/ProductVariantFormTest.php
@@ -26,9 +26,8 @@ class ProductVariantFormTest extends SuluTestCase
     }
 
     /**
-     * ProductDetailsDataMapper::mapDetailsData() resolves the `details/` fields of *any* product —
-     * variants included — against the product_details metadata. A field the variant form declares
-     * under a different name is submitted by the admin, matches nothing, and is silently dropped.
+     * mapDetailsData() resolves `details/` fields against the product_details metadata, for
+     * variants too. A field named differently here matches nothing and is dropped on save.
      */
     public function testVariantDetailFieldsAreDeclaredInProductDetailsToo(): void
     {

--- a/tests/Functional/HttpKernel/ProductVariantFormTest.php
+++ b/tests/Functional/HttpKernel/ProductVariantFormTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Product\Tests\Functional\HttpKernel;
+
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadataProvider;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+
+class ProductVariantFormTest extends SuluTestCase
+{
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        \restore_exception_handler();
+    }
+
+    /**
+     * ProductDetailsDataMapper::mapDetailsData() resolves the `details/` fields of *any* product —
+     * variants included — against the product_details metadata. A field the variant form declares
+     * under a different name is submitted by the admin, matches nothing, and is silently dropped.
+     */
+    public function testVariantDetailFieldsAreDeclaredInProductDetailsToo(): void
+    {
+        self::bootKernel();
+
+        /** @var FormMetadataProvider $provider */
+        $provider = self::getContainer()->get('sulu_admin.form_metadata_provider');
+
+        $variantForm = $provider->getMetadata('product_variant', 'en');
+        $this->assertInstanceOf(FormMetadata::class, $variantForm);
+        $productForm = $provider->getMetadata('product_details', 'en');
+        $this->assertInstanceOf(FormMetadata::class, $productForm);
+
+        $variantDetailFields = $this->detailFieldNames($variantForm);
+        $this->assertNotSame([], $variantDetailFields, 'Expected the variant form to declare detail fields.');
+
+        $productDetailFields = $this->detailFieldNames($productForm);
+
+        foreach ($variantDetailFields as $name) {
+            $this->assertContains(
+                $name,
+                $productDetailFields,
+                \sprintf('Variant field "%s" is not declared in product_details and would never be persisted.', $name),
+            );
+        }
+    }
+
+    public function testVariantFormCarriesTheSameDetailFieldsAsTheProduct(): void
+    {
+        self::bootKernel();
+
+        /** @var FormMetadataProvider $provider */
+        $provider = self::getContainer()->get('sulu_admin.form_metadata_provider');
+
+        $variantForm = $provider->getMetadata('product_variant', 'en');
+        $this->assertInstanceOf(FormMetadata::class, $variantForm);
+
+        $this->assertSame(
+            ['details/documents', 'details/image', 'details/shortDescription'],
+            $this->detailFieldNames($variantForm),
+        );
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function detailFieldNames(FormMetadata $form): array
+    {
+        $names = [];
+        foreach (\array_keys($form->getFlatFieldMetadata()) as $name) {
+            if (\str_starts_with($name, 'details/')) {
+                $names[] = $name;
+            }
+        }
+
+        \sort($names);
+
+        return $names;
+    }
+}

--- a/tests/Functional/HttpKernel/ProductsListFiltersTest.php
+++ b/tests/Functional/HttpKernel/ProductsListFiltersTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Product\Tests\Functional\HttpKernel;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use Sulu\Bundle\AdminBundle\Metadata\ListMetadata\ListMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\ListMetadata\ListMetadataProvider;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Product\Infrastructure\Sulu\Admin\ProductsListMetadataVisitor;
+
+#[CoversClass(ProductsListMetadataVisitor::class)]
+class ProductsListFiltersTest extends SuluTestCase
+{
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        \restore_exception_handler();
+    }
+
+    public function testProductFamilyIsFilterableAgainstTheFamilyList(): void
+    {
+        $field = $this->listMetadata()->getField('productFamily');
+
+        $this->assertSame('selection', $field->getFilterType());
+        $this->assertSame(
+            ['displayProperty' => 'name', 'resourceKey' => 'product_families'],
+            $field->getFilterTypeParameters(),
+        );
+    }
+
+    public function testTypeIsFilterableByTheTwoProductTypes(): void
+    {
+        $field = $this->listMetadata()->getField('type');
+
+        $this->assertSame('select', $field->getFilterType());
+        $this->assertSame(
+            [
+                'options' => [
+                    'product' => 'sulu_product.product_type_product',
+                    'product_with_variants' => 'sulu_product.product_type_product_with_variants',
+                ],
+            ],
+            $field->getFilterTypeParameters(),
+        );
+    }
+
+    /**
+     * The options come from the configured statuses, not from the list XML, so a project that
+     * configures its own statuses gets them in the filter too.
+     */
+    public function testStatusFilterOptionsComeFromTheConfiguredStatuses(): void
+    {
+        $field = $this->listMetadata()->getField('status');
+
+        $this->assertSame('select', $field->getFilterType());
+        $this->assertSame(
+            [
+                'options' => [
+                    'announced' => 'sulu_product.product_status.announced',
+                    'available' => 'sulu_product.product_status.available',
+                    'discontinued' => 'sulu_product.product_status.discontinued',
+                ],
+            ],
+            $field->getFilterTypeParameters(),
+        );
+    }
+
+    public function testPublishedStateIsFilterable(): void
+    {
+        $field = $this->listMetadata()->getField('publishedState');
+
+        $this->assertSame('select', $field->getFilterType());
+        $this->assertSame(
+            [
+                'options' => [
+                    'published' => 'sulu_content.state_published',
+                    'unpublished' => 'sulu_content.state_not_published',
+                    'draft' => 'sulu_admin.draft',
+                ],
+            ],
+            $field->getFilterTypeParameters(),
+        );
+    }
+
+    private function listMetadata(string $key = 'products'): ListMetadata
+    {
+        self::bootKernel();
+
+        /** @var ListMetadataProvider $provider */
+        $provider = self::getContainer()->get('sulu_admin.list_metadata_provider');
+
+        $metadata = $provider->getMetadata($key, 'en');
+        $this->assertInstanceOf(ListMetadata::class, $metadata);
+
+        return $metadata;
+    }
+}

--- a/tests/Functional/HttpKernel/ProductsListFiltersTest.php
+++ b/tests/Functional/HttpKernel/ProductsListFiltersTest.php
@@ -55,10 +55,6 @@ class ProductsListFiltersTest extends SuluTestCase
         );
     }
 
-    /**
-     * The options come from the configured statuses, not from the list XML, so a project that
-     * configures its own statuses gets them in the filter too.
-     */
     public function testStatusFilterOptionsComeFromTheConfiguredStatuses(): void
     {
         $field = $this->listMetadata()->getField('status');

--- a/tests/Functional/Integration/ProductControllerTest.php
+++ b/tests/Functional/Integration/ProductControllerTest.php
@@ -764,4 +764,67 @@ class ProductControllerTest extends SuluTestCase
         $ids = \array_column($listData['_embedded']['products'], 'id');
         $this->assertContains($id, $ids);
     }
+
+    public function testListFiltersByProductFamilyTypeAndStatus(): void
+    {
+        self::purgeDatabase();
+
+        $familyA = $this->createProductFamily();
+        $familyB = $this->createProductFamily();
+
+        $plainInA = $this->createProduct($familyA, 'Plain In A');
+        $withVariantsInA = $this->createProduct($familyA, 'Variants In A', ProductInterface::TYPE_PRODUCT_WITH_VARIANTS);
+        $plainInB = $this->createProduct($familyB, 'Plain In B');
+
+        $expectedFamilyA = [$plainInA, $withVariantsInA];
+        \sort($expectedFamilyA);
+        $this->assertSame($expectedFamilyA, $this->listIds(['productFamily' => $familyA]));
+
+        $this->assertSame(
+            [$withVariantsInA],
+            $this->listIds(['type' => ProductInterface::TYPE_PRODUCT_WITH_VARIANTS]),
+        );
+
+        $this->assertSame(
+            [$plainInB],
+            $this->listIds(['productFamily' => $familyB, 'type' => ProductInterface::TYPE_PRODUCT]),
+        );
+
+        // every product defaults to the "available" status
+        $expectedAll = [$plainInA, $withVariantsInA, $plainInB];
+        \sort($expectedAll);
+        $this->assertSame($expectedAll, $this->listIds(['status' => 'available']));
+        $this->assertSame([], $this->listIds(['status' => 'discontinued']));
+
+        // nothing is published yet, so the whole list sits in "unpublished"
+        $this->assertSame($expectedAll, $this->listIds(['publishedState' => 'unpublished']));
+        $this->assertSame([], $this->listIds(['publishedState' => 'published']));
+
+        $this->client->request('POST', '/admin/api/products/' . $plainInA . '.json?locale=en&action=publish');
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
+
+        $this->assertSame([$plainInA], $this->listIds(['publishedState' => 'published']));
+    }
+
+    /**
+     * @param array<string, string> $filter
+     *
+     * @return array<int, string>
+     */
+    private function listIds(array $filter): array
+    {
+        $this->client->request('GET', '/admin/api/products.json?locale=en', ['filter' => $filter]);
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
+
+        $data = \json_decode((string) $this->client->getResponse()->getContent(), true);
+        $this->assertIsArray($data);
+        $this->assertIsArray($data['_embedded']);
+        $this->assertIsArray($data['_embedded']['products']);
+
+        /** @var array<int, string> $ids */
+        $ids = \array_column($data['_embedded']['products'], 'id');
+        \sort($ids);
+
+        return $ids;
+    }
 }

--- a/tests/Functional/Integration/ProductControllerTest.php
+++ b/tests/Functional/Integration/ProductControllerTest.php
@@ -827,4 +827,25 @@ class ProductControllerTest extends SuluTestCase
 
         return $ids;
     }
+
+    /**
+     * A single selection loads the whole item from the detail endpoint, so its display property has to
+     * exist there. The list column is called "name" while the detail response only carries "title".
+     */
+    public function testSingleProductSelectionDisplayPropertyExistsInDetailResponse(): void
+    {
+        self::purgeDatabase();
+
+        $familyId = $this->createProductFamily();
+        $productId = $this->createProduct($familyId, 'Selectable Product');
+
+        $this->client->request('GET', '/admin/api/products/' . $productId . '.json?locale=en');
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
+
+        $data = \json_decode((string) $this->client->getResponse()->getContent(), true);
+        $this->assertIsArray($data);
+
+        $this->assertArrayHasKey('title', $data);
+        $this->assertSame('Selectable Product', $data['title']);
+    }
 }

--- a/tests/Functional/Integration/ProductVariantControllerTest.php
+++ b/tests/Functional/Integration/ProductVariantControllerTest.php
@@ -833,6 +833,70 @@ class ProductVariantControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(422, $this->client->getResponse());
     }
 
+    public function testParentWithRequiredVariantAttributeIsSavable(): void
+    {
+        self::purgeDatabase();
+
+        // A required variant axis is only ever rendered on the variant overlay, so the parent
+        // has no field to satisfy it with — enforcing it there made the parent unsavable.
+        $axisId = $this->createAttribute('size', 'Size');
+        $familyId = $this->createProductFamily([
+            $axisId => ['enabled' => true, 'required' => true, 'variantSpecific' => true],
+        ]);
+        $parentId = $this->createProduct($familyId, 'Parent Product', ProductInterface::TYPE_PRODUCT_WITH_VARIANTS);
+
+        $this->client->request(
+            'PUT',
+            '/admin/api/products/' . $parentId . '.json?locale=en',
+            [],
+            [],
+            [],
+            \json_encode([
+                'locale' => 'en',
+                'title' => 'Parent Product',
+                'attributes' => [],
+            ]) ?: null,
+        );
+
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
+    }
+
+    public function testVariantPersistsDetailsFields(): void
+    {
+        self::purgeDatabase();
+
+        $familyId = $this->createProductFamily();
+        $parentId = $this->createProduct($familyId, 'Parent Product', ProductInterface::TYPE_PRODUCT_WITH_VARIANTS);
+        $variantId = $this->createVariant($parentId);
+
+        $this->client->request(
+            'PUT',
+            '/admin/api/products/' . $parentId . '/variants/' . $variantId . '.json?locale=en',
+            [],
+            [],
+            [],
+            \json_encode([
+                'locale' => 'en',
+                'code' => 'CX3-RD-L',
+                'title' => 'Variant L',
+                'details' => ['shortDescription' => '<p>Variant blurb</p>'],
+            ]) ?: null,
+        );
+
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
+
+        $this->client->request(
+            'GET',
+            '/admin/api/products/' . $parentId . '/variants/' . $variantId . '.json?locale=en',
+        );
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
+
+        $data = \json_decode((string) $this->client->getResponse()->getContent(), true);
+        $this->assertIsArray($data);
+        $this->assertIsArray($data['details']);
+        $this->assertSame('<p>Variant blurb</p>', $data['details']['shortDescription']);
+    }
+
     public function testCreatingAVariantMarksParentAsHavingUnpublishedChanges(): void
     {
         self::purgeDatabase();

--- a/tests/Functional/Integration/ProductVariantControllerTest.php
+++ b/tests/Functional/Integration/ProductVariantControllerTest.php
@@ -837,8 +837,7 @@ class ProductVariantControllerTest extends SuluTestCase
     {
         self::purgeDatabase();
 
-        // A required variant axis is only ever rendered on the variant overlay, so the parent
-        // has no field to satisfy it with — enforcing it there made the parent unsavable.
+        // the axis is only rendered on the variant overlay, so the parent cannot satisfy it
         $axisId = $this->createAttribute('size', 'Size');
         $familyId = $this->createProductFamily([
             $axisId => ['enabled' => true, 'required' => true, 'variantSpecific' => true],

--- a/tests/Unit/Infrastructure/Sulu/Admin/ProductAdminTest.php
+++ b/tests/Unit/Infrastructure/Sulu/Admin/ProductAdminTest.php
@@ -20,12 +20,15 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\ActivityBundle\Infrastructure\Sulu\Admin\ActivityAdmin;
 use Sulu\Bundle\ActivityBundle\Infrastructure\Sulu\Admin\View\ActivityViewBuilderFactory;
 use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItemCollection;
+use Sulu\Bundle\AdminBundle\Admin\View\FormViewBuilder;
+use Sulu\Bundle\AdminBundle\Admin\View\PreviewFormViewBuilder;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactory;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
 use Sulu\Component\Localization\Manager\LocalizationManagerInterface;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
 use Sulu\Product\Domain\Association\ProductAssociationTypeRegistry;
+use Sulu\Product\Domain\Model\ProductDimensionContentInterface;
 use Sulu\Product\Infrastructure\Sulu\Admin\AttributeAdmin;
 use Sulu\Product\Infrastructure\Sulu\Admin\AttributeGroupAdmin;
 use Sulu\Product\Infrastructure\Sulu\Admin\ProductAdmin;
@@ -225,6 +228,32 @@ class ProductAdminTest extends TestCase
         $this->assertTrue($viewCollection->has(ProductAdmin::ADD_TABS_VIEW . '.details'));
         $this->assertTrue($viewCollection->has(ProductAdmin::EDIT_TABS_VIEW . '.details'));
         $this->assertTrue($viewCollection->has(ProductAdmin::EDIT_TABS_VIEW . '.variants'));
+    }
+
+    public function testDetailsEditViewRendersPreview(): void
+    {
+        $this->securityChecker->hasPermission(ProductAdmin::SECURITY_CONTEXT, PermissionTypes::EDIT)->willReturn(true);
+        $this->securityChecker->hasPermission(ProductAdmin::SECURITY_CONTEXT, PermissionTypes::ADD)->willReturn(false);
+        $this->securityChecker->hasPermission(ProductAdmin::SECURITY_CONTEXT, PermissionTypes::DELETE)->willReturn(false);
+        $this->securityChecker->hasPermission(ProductAdmin::SECURITY_CONTEXT, PermissionTypes::VIEW)->willReturn(false);
+        $this->securityChecker->hasPermission(ProductAdmin::SECURITY_CONTEXT, PermissionTypes::LIVE)->willReturn(false);
+        $this->securityChecker->hasPermission(ActivityAdmin::SECURITY_CONTEXT, PermissionTypes::VIEW)->willReturn(false);
+
+        $viewCollection = new ViewCollection();
+        $this->admin->configureViews($viewCollection);
+
+        $editView = $viewCollection->get(ProductAdmin::EDIT_TABS_VIEW . '.details')->getView();
+        $this->assertSame(PreviewFormViewBuilder::TYPE, $editView->getType());
+        // the preview object provider is tagged for the dimension content, not the product itself
+        $this->assertSame(
+            ProductDimensionContentInterface::RESOURCE_KEY,
+            $editView->getOption('previewResourceKey'),
+        );
+        $this->assertSame('workflowPlace != null', $editView->getOption('previewCondition'));
+
+        // nothing to preview before the product exists
+        $addView = $viewCollection->get(ProductAdmin::ADD_TABS_VIEW . '.details')->getView();
+        $this->assertSame(FormViewBuilder::TYPE, $addView->getType());
     }
 
     public function testConfigureViewsAddsVariantsTabView(): void

--- a/tests/Unit/Infrastructure/Sulu/Admin/ProductAttributeFormMetadataVisitorTest.php
+++ b/tests/Unit/Infrastructure/Sulu/Admin/ProductAttributeFormMetadataVisitorTest.php
@@ -32,12 +32,9 @@ use Sulu\Product\Domain\Model\AttributeGroupInterface;
 use Sulu\Product\Domain\Model\AttributeGroupTranslationInterface;
 use Sulu\Product\Domain\Model\AttributeInterface;
 use Sulu\Product\Domain\Model\AttributeTranslationInterface;
-use Sulu\Product\Domain\Model\Product;
 use Sulu\Product\Domain\Model\ProductFamilyAttributeInterface;
 use Sulu\Product\Domain\Model\ProductFamilyInterface;
-use Sulu\Product\Domain\Model\ProductInterface;
 use Sulu\Product\Domain\Repository\ProductFamilyRepositoryInterface;
-use Sulu\Product\Domain\Repository\ProductRepositoryInterface;
 use Sulu\Product\Infrastructure\Sulu\Admin\AttributeFieldFactory;
 use Sulu\Product\Infrastructure\Sulu\Admin\ProductAttributeFormMetadataVisitor;
 use Symfony\Component\DependencyInjection\Container;
@@ -54,14 +51,10 @@ class ProductAttributeFormMetadataVisitorTest extends TestCase
     /** @var ObjectProphecy<FormMetadataLoaderInterface> */
     private ObjectProphecy $formMetadataLoader;
 
-    /** @var ObjectProphecy<ProductRepositoryInterface> */
-    private ObjectProphecy $productRepository;
-
     protected function setUp(): void
     {
         $this->productFamilyRepository = $this->prophesize(ProductFamilyRepositoryInterface::class);
         $this->formMetadataLoader = $this->prophesize(FormMetadataLoaderInterface::class);
-        $this->productRepository = $this->prophesize(ProductRepositoryInterface::class);
     }
 
     private function visitor(): ProductAttributeFormMetadataVisitor
@@ -87,7 +80,6 @@ class ProductAttributeFormMetadataVisitorTest extends TestCase
             ),
             new PropertyMetadataMapperRegistry($mapperContainer),
             $translator,
-            $this->productRepository->reveal(),
         );
     }
 
@@ -157,6 +149,7 @@ class ProductAttributeFormMetadataVisitorTest extends TestCase
         $attribute->getGroup()->willReturn($this->group());
 
         $familyAttribute = $this->prophesize(ProductFamilyAttributeInterface::class);
+        $familyAttribute->isVariantSpecific()->willReturn(false);
         $familyAttribute->getAttribute()->willReturn($attribute->reveal());
         $familyAttribute->isRequired()->willReturn(true);
 
@@ -213,6 +206,7 @@ class ProductAttributeFormMetadataVisitorTest extends TestCase
         $attribute->getGroup()->willReturn($this->group(9, $groupName));
 
         $familyAttribute = $this->prophesize(ProductFamilyAttributeInterface::class);
+        $familyAttribute->isVariantSpecific()->willReturn(false);
         $familyAttribute->getAttribute()->willReturn($attribute->reveal());
         $familyAttribute->isRequired()->willReturn(false);
 
@@ -259,6 +253,7 @@ class ProductAttributeFormMetadataVisitorTest extends TestCase
         $attribute->getGroup()->willReturn($group->reveal());
 
         $familyAttribute = $this->prophesize(ProductFamilyAttributeInterface::class);
+        $familyAttribute->isVariantSpecific()->willReturn(false);
         $familyAttribute->getAttribute()->willReturn($attribute->reveal());
         $familyAttribute->isRequired()->willReturn(false);
 
@@ -296,6 +291,7 @@ class ProductAttributeFormMetadataVisitorTest extends TestCase
         $attribute->getGroup()->willReturn($this->group());
 
         $familyAttribute = $this->prophesize(ProductFamilyAttributeInterface::class);
+        $familyAttribute->isVariantSpecific()->willReturn(false);
         $familyAttribute->getAttribute()->willReturn($attribute->reveal());
         $familyAttribute->isRequired()->willReturn(true);
 
@@ -347,6 +343,7 @@ class ProductAttributeFormMetadataVisitorTest extends TestCase
         $attribute->getGroup()->willReturn($this->group());
 
         $familyAttribute = $this->prophesize(ProductFamilyAttributeInterface::class);
+        $familyAttribute->isVariantSpecific()->willReturn(false);
         $familyAttribute->getAttribute()->willReturn($attribute->reveal());
         $familyAttribute->isRequired()->willReturn(false);
 
@@ -376,6 +373,7 @@ class ProductAttributeFormMetadataVisitorTest extends TestCase
         $attribute->getConfig()->willReturn([]);
 
         $familyAttribute = $this->prophesize(ProductFamilyAttributeInterface::class);
+        $familyAttribute->isVariantSpecific()->willReturn(false);
         $familyAttribute->getAttribute()->willReturn($attribute->reveal());
 
         $family = $this->prophesize(ProductFamilyInterface::class);
@@ -398,6 +396,7 @@ class ProductAttributeFormMetadataVisitorTest extends TestCase
         $attribute->getConfig()->willReturn([]);
 
         $familyAttribute = $this->prophesize(ProductFamilyAttributeInterface::class);
+        $familyAttribute->isVariantSpecific()->willReturn(false);
         $familyAttribute->getAttribute()->willReturn($attribute->reveal());
 
         $family = $this->prophesize(ProductFamilyInterface::class);
@@ -429,6 +428,7 @@ class ProductAttributeFormMetadataVisitorTest extends TestCase
         $attribute->getGroup()->willReturn($this->group());
 
         $familyAttribute = $this->prophesize(ProductFamilyAttributeInterface::class);
+        $familyAttribute->isVariantSpecific()->willReturn(false);
         $familyAttribute->getAttribute()->willReturn($attribute->reveal());
         $familyAttribute->isRequired()->willReturn(false);
 
@@ -471,6 +471,7 @@ class ProductAttributeFormMetadataVisitorTest extends TestCase
         $attribute->getConfig()->willReturn([]);
 
         $familyAttribute = $this->prophesize(ProductFamilyAttributeInterface::class);
+        $familyAttribute->isVariantSpecific()->willReturn(false);
         $familyAttribute->getAttribute()->willReturn($attribute->reveal());
 
         $family = $this->prophesize(ProductFamilyInterface::class);
@@ -508,6 +509,7 @@ class ProductAttributeFormMetadataVisitorTest extends TestCase
         $attribute->getGroup()->willReturn($this->group());
 
         $familyAttribute = $this->prophesize(ProductFamilyAttributeInterface::class);
+        $familyAttribute->isVariantSpecific()->willReturn(false);
         $familyAttribute->getAttribute()->willReturn($attribute->reveal());
         $familyAttribute->isRequired()->willReturn(false);
 
@@ -576,6 +578,7 @@ class ProductAttributeFormMetadataVisitorTest extends TestCase
         $attribute->getGroup()->willReturn($this->group());
 
         $familyAttribute = $this->prophesize(ProductFamilyAttributeInterface::class);
+        $familyAttribute->isVariantSpecific()->willReturn(false);
         $familyAttribute->getAttribute()->willReturn($attribute->reveal());
         $familyAttribute->isRequired()->willReturn(false);
 
@@ -628,6 +631,7 @@ class ProductAttributeFormMetadataVisitorTest extends TestCase
         $attribute->getGroup()->willReturn($this->group());
 
         $familyAttribute = $this->prophesize(ProductFamilyAttributeInterface::class);
+        $familyAttribute->isVariantSpecific()->willReturn(false);
         $familyAttribute->getAttribute()->willReturn($attribute->reveal());
         $familyAttribute->isRequired()->willReturn(false);
 
@@ -650,7 +654,7 @@ class ProductAttributeFormMetadataVisitorTest extends TestCase
         self::assertSame('Gewicht', $field->getLabel('en'));
     }
 
-    public function testSkipsVariantAttributesForVariantProduct(): void
+    public function testSkipsVariantAttributesForEveryProductType(): void
     {
         $translation = $this->prophesize(AttributeTranslationInterface::class);
         $translation->getName()->willReturn('Weight');
@@ -682,10 +686,6 @@ class ProductAttributeFormMetadataVisitorTest extends TestCase
         $this->formMetadataLoader->getMetadata('product_attribute_number', 'en', [])
             ->willReturn($this->fragmentWithValueField());
 
-        $product = $this->prophesize(Product::class);
-        $product->isType(ProductInterface::TYPE_PRODUCT_WITH_VARIANTS)->willReturn(true);
-        $this->productRepository->findOneBy(['uuid' => 'uuid-1'])->willReturn($product->reveal());
-
         $form = new FormMetadata();
         $form->setKey('product_details');
 
@@ -713,6 +713,7 @@ class ProductAttributeFormMetadataVisitorTest extends TestCase
         $attribute7->getGroup()->willReturn($this->group(1, 'Dimensions'));
 
         $familyAttribute7 = $this->prophesize(ProductFamilyAttributeInterface::class);
+        $familyAttribute7->isVariantSpecific()->willReturn(false);
         $familyAttribute7->getAttribute()->willReturn($attribute7->reveal());
         $familyAttribute7->isRequired()->willReturn(false);
 
@@ -729,6 +730,7 @@ class ProductAttributeFormMetadataVisitorTest extends TestCase
         $attribute8->getGroup()->willReturn($this->group(2, 'Electrical'));
 
         $familyAttribute8 = $this->prophesize(ProductFamilyAttributeInterface::class);
+        $familyAttribute8->isVariantSpecific()->willReturn(false);
         $familyAttribute8->getAttribute()->willReturn($attribute8->reveal());
         $familyAttribute8->isRequired()->willReturn(false);
 

--- a/tests/Unit/Infrastructure/Sulu/Admin/ProductCodeFormMetadataVisitorTest.php
+++ b/tests/Unit/Infrastructure/Sulu/Admin/ProductCodeFormMetadataVisitorTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Product\Tests\Unit\Infrastructure\Sulu\Admin;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SchemaMetadata;
+use Sulu\Product\Infrastructure\Sulu\Admin\ProductCodeFormMetadataVisitor;
+
+#[CoversClass(ProductCodeFormMetadataVisitor::class)]
+class ProductCodeFormMetadataVisitorTest extends TestCase
+{
+    public function testLeavesOtherFormsUntouched(): void
+    {
+        $formMetadata = new FormMetadata();
+        $formMetadata->setKey('product_variant');
+        $formMetadata->setSchema(new SchemaMetadata());
+
+        (new ProductCodeFormMetadataVisitor())->visitFormMetadata($formMetadata, 'en');
+
+        $this->assertArrayNotHasKey('allOf', $formMetadata->getSchema()->toJsonSchema());
+    }
+
+    public function testCodeIsRequiredForPlainProductsOnly(): void
+    {
+        $formMetadata = new FormMetadata();
+        $formMetadata->setKey('product_details');
+        $formMetadata->setSchema(new SchemaMetadata());
+
+        (new ProductCodeFormMetadataVisitor())->visitFormMetadata($formMetadata, 'en');
+
+        $this->assertSame(
+            [
+                'allOf' => [
+                    [
+                        'type' => ['number', 'string', 'boolean', 'object', 'array', 'null'],
+                    ],
+                    [
+                        'anyOf' => [
+                            [
+                                'type' => 'object',
+                                'properties' => [
+                                    'type' => ['const' => 'product_with_variants'],
+                                ],
+                            ],
+                            [
+                                'type' => 'object',
+                                'properties' => [
+                                    'type' => ['const' => 'product'],
+                                    // minLength, because a bare `required` would accept the `null`
+                                    // that a code-less product loads with
+                                    'code' => ['type' => 'string', 'minLength' => 1],
+                                ],
+                                'required' => ['code'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            $formMetadata->getSchema()->toJsonSchema(),
+        );
+    }
+}

--- a/tests/Unit/Infrastructure/Sulu/Admin/ProductCodeFormMetadataVisitorTest.php
+++ b/tests/Unit/Infrastructure/Sulu/Admin/ProductCodeFormMetadataVisitorTest.php
@@ -59,8 +59,7 @@ class ProductCodeFormMetadataVisitorTest extends TestCase
                                 'type' => 'object',
                                 'properties' => [
                                     'type' => ['const' => 'product'],
-                                    // minLength, because a bare `required` would accept the `null`
-                                    // that a code-less product loads with
+                                    // a bare `required` would accept the `null` a code-less product loads with
                                     'code' => ['type' => 'string', 'minLength' => 1],
                                 ],
                                 'required' => ['code'],

--- a/tests/Unit/Infrastructure/Sulu/Admin/ProductContentAdminTest.php
+++ b/tests/Unit/Infrastructure/Sulu/Admin/ProductContentAdminTest.php
@@ -99,8 +99,7 @@ class ProductContentAdminTest extends TestCase
     }
 
     /**
-     * The content views ship with tab orders that collide with the product's own tabs
-     * (content defaults to 20, the same as variants; seo to 30, the same as associations).
+     * Content defaults to 20 like variants, seo to 30 like associations.
      */
     public function testContentViewsAreOrderedBehindTheProductsOwnTabs(): void
     {

--- a/tests/Unit/Infrastructure/Sulu/Admin/ProductContentAdminTest.php
+++ b/tests/Unit/Infrastructure/Sulu/Admin/ProductContentAdminTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\AdminBundle\Admin\View\FormViewBuilderInterface;
 use Sulu\Bundle\AdminBundle\Admin\View\PreviewFormViewBuilderInterface;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderInterface;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
@@ -95,5 +96,49 @@ class ProductContentAdminTest extends TestCase
         $this->admin->configureViews($viewCollection);
 
         $this->assertCount(2, $viewCollection->all());
+    }
+
+    /**
+     * The content views ship with tab orders that collide with the product's own tabs
+     * (content defaults to 20, the same as variants; seo to 30, the same as associations).
+     */
+    public function testContentViewsAreOrderedBehindTheProductsOwnTabs(): void
+    {
+        $this->securityChecker->hasPermission(ProductAdmin::SECURITY_CONTEXT, PermissionTypes::EDIT)
+            ->willReturn(true);
+
+        $this->contentViewBuilderFactory->getDefaultToolbarActions(ProductInterface::class)
+            ->willReturn([]);
+
+        $expectedOrders = [
+            ProductAdmin::EDIT_TABS_VIEW . '.content' => 40,
+            ProductAdmin::EDIT_TABS_VIEW . '.seo' => 50,
+            ProductAdmin::EDIT_TABS_VIEW . '.excerpt' => 60,
+            ProductAdmin::EDIT_TABS_VIEW . '.settings' => 70,
+        ];
+
+        $viewBuilders = [];
+        foreach ($expectedOrders as $name => $tabOrder) {
+            $viewBuilder = $this->prophesize(FormViewBuilderInterface::class);
+            $viewBuilder->getName()->willReturn($name);
+            $viewBuilder->setTabOrder($tabOrder)->shouldBeCalled();
+            $viewBuilders[] = $viewBuilder->reveal();
+        }
+
+        // the insights views carry no tab order of ours and must be left alone
+        $insights = $this->prophesize(FormViewBuilderInterface::class);
+        $insights->getName()->willReturn(ProductAdmin::EDIT_TABS_VIEW . '.insights');
+        $insights->setTabOrder(Argument::any())->shouldNotBeCalled();
+        $viewBuilders[] = $insights->reveal();
+
+        $this->contentViewBuilderFactory->createViews(
+            ProductInterface::class,
+            ProductAdmin::EDIT_TABS_VIEW,
+            null,
+            ProductAdmin::SECURITY_CONTEXT,
+            Argument::any(),
+        )->willReturn($viewBuilders);
+
+        $this->admin->configureViews(new ViewCollection());
     }
 }

--- a/tests/Unit/Infrastructure/Sulu/Content/DataMapper/ProductAttributesDataMapperTest.php
+++ b/tests/Unit/Infrastructure/Sulu/Content/DataMapper/ProductAttributesDataMapperTest.php
@@ -343,6 +343,20 @@ class ProductAttributesDataMapperTest extends TestCase
         $this->mapper->map($fixture['unloc'], $fixture['loc'], ['attributes' => [1 => null]]);
     }
 
+    /**
+     * Regression: a required variant axis is not rendered on the product form at all, so enforcing
+     * it against the product made a product with variants impossible to save.
+     */
+    public function testProductSkipsRequiredVariantAttribute(): void
+    {
+        $fixture = $this->makeProductFixture(1, required: true, isVariantAttribute: true, isVariantResource: false);
+        $fixture['unloc_prophecy']->addAttribute(Argument::cetera())->shouldNotBeCalled();
+
+        $this->mapper->map($fixture['unloc'], $fixture['loc'], ['attributes' => [1 => null]]);
+
+        $this->addToAssertionCount(1);
+    }
+
     private function prophesizeNonVariantResource(): ProductInterface
     {
         /** @var ObjectProphecy<ProductInterface> $resource */

--- a/tests/Unit/Infrastructure/Sulu/Content/DataMapper/ProductAttributesDataMapperTest.php
+++ b/tests/Unit/Infrastructure/Sulu/Content/DataMapper/ProductAttributesDataMapperTest.php
@@ -344,8 +344,8 @@ class ProductAttributesDataMapperTest extends TestCase
     }
 
     /**
-     * Regression: a required variant axis is not rendered on the product form at all, so enforcing
-     * it against the product made a product with variants impossible to save.
+     * Regression: enforcing a variant axis against the product made a product with variants
+     * impossible to save.
      */
     public function testProductSkipsRequiredVariantAttribute(): void
     {

--- a/translations/admin.de.json
+++ b/translations/admin.de.json
@@ -100,6 +100,7 @@
     "sulu_product.short_description": "Kurzbeschreibung",
     "sulu_product.image": "Produktbild",
     "sulu_product.documents": "Produktdokumente",
+    "sulu_product.media": "Medien",
     "sulu_product.product_status.announced": "Angekündigt",
     "sulu_product.product_status.available": "Verfügbar",
     "sulu_product.product_status.discontinued": "Eingestellt",

--- a/translations/admin.en.json
+++ b/translations/admin.en.json
@@ -99,6 +99,7 @@
     "sulu_product.short_description": "Short description",
     "sulu_product.image": "Product image",
     "sulu_product.documents": "Product documents",
+    "sulu_product.media": "Media",
     "sulu_product.product_status.announced": "Announced",
     "sulu_product.product_status.available": "Available",
     "sulu_product.product_status.discontinued": "Discontinued",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | yes
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

**Fixes**

* A required variant attribute is only enforced on variants now, no longer on the product that owns them. Variant axes are hidden from the product form for every product type, so form and validation agree.
* The variant form declared `shortDescription`, `image` and `documents` at top level, where no data mapper reads them. They are now declared under `details/` like on the product form and actually persist.
* A selected `single_product_selection` rendered an empty row. It displayed the `name` property, but a single selection loads the whole item from the detail endpoint, which only carries `title`. The multi `product_selection` keeps `name` because it loads from the list endpoint.

**Product code**

* Always visible, also for `product_with_variants`.
* Mandatory for plain products, optional for products with variants. Implemented as a schema branch on the product type so it follows the type select live, with a non empty constraint because a bare `required` would accept the `null` a code less product loads with.

**Admin UI**

* The details tab renders a preview.
* Tab order is details, variants, associations, then the content tabs. The content views default to orders that collided with variants and associations.
* Product and variant forms share one layout: name full width, code and status in one row, family and type in one row, media in its own section with both pickers full width.
* The form label for the product name is `Name` now, matching the list column.
* The edit tab header shows the product name. It was configured to read a `name` property that the detail endpoint never returns, so it stayed empty.

**List filters**

* Product family, type, status and published state.
* Status options come from the configured product statuses rather than the list XML, so projects that configure their own statuses get them in the filter too.

#### Why?

* A product with variants could not be saved at all once its family marked a variant axis as required, because that field is only rendered on the variant overlay.
* Variant description and media values were silently dropped on save.
* The product and variant forms had drifted apart in field order, column widths and labels.
* Reviewers asked for the product code to stay visible on products with variants and for filters on the products list.

#### To Do

- [ ] Create a documentation PR
