### PR TITLE
Fix the product versions endpoint

### DIFF
--- a/src/Domain/Model/ProductInterface.php
+++ b/src/Domain/Model/ProductInterface.php
@@ -29,6 +29,8 @@ interface ProductInterface extends AuditableInterface, ContentRichEntityInterfac
     public const LIST_KEY_VARIANTS = 'product_variants';
     public const FORM_KEY_VARIANT = 'product_variant';
 
+    public const LIST_KEY_VERSIONS = 'products_versions';
+
     public const TYPE_PRODUCT = 'product';
     public const TYPE_PRODUCT_WITH_VARIANTS = 'product_with_variants';
     public const TYPE_VARIANT = 'variant';

--- a/src/Infrastructure/Symfony/HttpKernel/SuluProductBundle.php
+++ b/src/Infrastructure/Symfony/HttpKernel/SuluProductBundle.php
@@ -1215,7 +1215,7 @@ final class SuluProductBundle extends AbstractBundle
                                 'detail' => 'sulu_product.get_product',
                             ],
                         ],
-                        'products_versions' => [
+                        ProductInterface::LIST_KEY_VERSIONS => [
                             'routes' => [
                                 'list' => 'sulu_product.get_product_versions',
                                 'detail' => 'sulu_product.get_product',

--- a/src/UserInterface/Controller/Admin/ProductController.php
+++ b/src/UserInterface/Controller/Admin/ProductController.php
@@ -223,7 +223,7 @@ final class ProductController implements SecuredControllerInterface
         $locale = $this->getLocale($request);
 
         /** @var DoctrineFieldDescriptorInterface[] $fieldDescriptors */
-        $fieldDescriptors = $this->fieldDescriptorFactory->getFieldDescriptors('products_versions');
+        $fieldDescriptors = $this->fieldDescriptorFactory->getFieldDescriptors(ProductInterface::LIST_KEY_VERSIONS);
         /** @var DoctrineListBuilder $listBuilder */
         $listBuilder = $this->listBuilderFactory->create(ProductInterface::class);
         $listBuilder->setParameter('locale', $locale);
@@ -235,8 +235,8 @@ final class ProductController implements SecuredControllerInterface
         $result = $listBuilder->execute();
         $listRepresentation = new PaginatedRepresentation(
             $result,
-            'products_versions',
-            $listBuilder->getCurrentPage(),
+            ProductInterface::LIST_KEY_VERSIONS,
+            (int) $listBuilder->getCurrentPage(),
             (int) $listBuilder->getLimit(),
             $listBuilder->count(),
         );

--- a/tests/Functional/HttpKernel/ProductVersionsViewTest.php
+++ b/tests/Functional/HttpKernel/ProductVersionsViewTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Product\Tests\Functional\HttpKernel;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use Sulu\Bundle\AdminBundle\Admin\View\View;
+use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
+use Sulu\Bundle\AdminBundle\Metadata\ListMetadata\ListMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\ListMetadata\ListMetadataProvider;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Product\Infrastructure\Sulu\Admin\ProductAdmin;
+use Sulu\Product\Infrastructure\Sulu\Admin\ProductContentAdmin;
+
+/**
+ * The content bundle derives the versions keys from the dimension content resource key, so it only
+ * finds the registered "products_versions" list while that key stays aligned with the product one.
+ */
+#[CoversClass(ProductContentAdmin::class)]
+class ProductVersionsViewTest extends SuluTestCase
+{
+    private const VERSIONS_VIEW = ProductAdmin::EDIT_TABS_VIEW . '.insights.versions';
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        \restore_exception_handler();
+    }
+
+    public function testVersionsListKeyResolvesToListMetadata(): void
+    {
+        self::bootKernel();
+
+        $listKey = $this->getVersionsView()->getOption('listKey');
+        $this->assertSame('products_versions', $listKey);
+
+        /** @var ListMetadataProvider $listMetadataProvider */
+        $listMetadataProvider = self::getContainer()->get('sulu_admin.list_metadata_provider');
+
+        // the admin requests /admin/metadata/list/<listKey>, which answers 404 without metadata
+        $this->assertInstanceOf(ListMetadata::class, $listMetadataProvider->getMetadata($listKey, 'en'));
+    }
+
+    public function testVersionsResourceKeyIsRegisteredWithAListRoute(): void
+    {
+        self::bootKernel();
+
+        $resourceKey = $this->getVersionsView()->getOption('resourceKey');
+        $this->assertSame('products_versions', $resourceKey);
+
+        /** @var array<string, array{routes: array<string, string>}> $resources */
+        $resources = self::getContainer()->getParameter('sulu_admin.resources');
+
+        $this->assertArrayHasKey($resourceKey, $resources);
+        $this->assertArrayHasKey('list', $resources[$resourceKey]['routes']);
+    }
+
+    private function getVersionsView(): View
+    {
+        /** @var ProductContentAdmin $admin */
+        $admin = self::getContainer()->get('sulu_product.product_content_admin');
+
+        $viewCollection = new ViewCollection();
+        $admin->configureViews($viewCollection);
+
+        return $viewCollection->get(self::VERSIONS_VIEW)->getView();
+    }
+}

--- a/tests/Functional/Integration/ProductControllerTest.php
+++ b/tests/Functional/Integration/ProductControllerTest.php
@@ -883,4 +883,32 @@ class ProductControllerTest extends SuluTestCase
         $this->assertTrue($byId[$publishedId]['publishedState']);
         $this->assertNotNull($byId[$publishedId]['published']);
     }
+
+    public function testGetVersionsListsPublishedVersions(): void
+    {
+        self::purgeDatabase();
+        $familyId = $this->createProductFamily();
+        $id = $this->createProduct($familyId, 'Versioned Product');
+
+        $this->client->request('POST', '/admin/api/products/' . $id . '.json?locale=en&action=publish');
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
+
+        // the parameters the versions tab sends
+        $this->client->request(
+            'GET',
+            '/admin/api/products/' . $id . '/versions?page=1&locale=en&limit=10&fields=title,version,changer,id&flat=true',
+        );
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        $data = \json_decode((string) $response->getContent(), true);
+        $this->assertIsArray($data);
+        $this->assertSame(1, $data['page']);
+        $this->assertIsArray($data['_embedded']);
+        $this->assertIsArray($data['_embedded']['products_versions']);
+        $this->assertCount(1, $data['_embedded']['products_versions']);
+        $version = $data['_embedded']['products_versions'][0];
+        $this->assertIsArray($version);
+        $this->assertSame('Versioned Product', $version['title']);
+    }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | #404
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

The versions tab under insights loads its list metadata but the list request itself answers 500, so the table stays empty.

* `ProductController::getVersionsAction()` passed `$listBuilder->getCurrentPage()` straight into `PaginatedRepresentation`. That getter returns the raw query value as a string while the constructor argument is `?int`, and this file declares `strict_types`, so the call throws. It is now cast, which is what every other list action in the bundle already does. The same uncast call sits in the core page, article and snippet controllers, but those files do not declare `strict_types`, so PHP coerces the value and they get away with it.
* The `products_versions` literal appeared in three places, the resource registration in `SuluProductBundle` and both the field descriptor lookup and the representation rel in the controller. It is now `ProductInterface::LIST_KEY_VERSIONS`, defined once.

Tests:

* `ProductVersionsViewTest` covers the two things the tab needs before it ever reaches the endpoint, that the view's `listKey` resolves to real list metadata and that its `resourceKey` is registered with a list route. The content bundle derives the versions keys from the dimension content resource key, so the registered `products_versions` list is only found while that key stays aligned with the product one. Splitting them again would break the tab silently, and these fail instead.
* `ProductControllerTest::testGetVersionsListsPublishedVersions` calls the endpoint with the exact query the tab sends, and asserts the paginated envelope the table reads.

Verified in the browser. The table renders both versions of a product with title, publish date and changer, and restoring a version returns 200 and navigates back to the details view.

#### Why?

The tab has never worked. It failed twice over, first with a 404 on `/admin/metadata/list/product_contents_versions` and then with this 500. #404 dropped the separate dimension content resource key, which fixed the first failure and made the workaround this PR originally carried unnecessary, so only the endpoint fix and its tests remain.

#### To Do

- [ ] Create a documentation PR
