### PR TITLE
Drop the separate product content resource key

### DIFF
--- a/src/Domain/Model/ProductDimensionContent.php
+++ b/src/Domain/Model/ProductDimensionContent.php
@@ -133,7 +133,7 @@ class ProductDimensionContent implements ProductDimensionContentInterface
 
     public static function getResourceKey(): string
     {
-        return ProductDimensionContentInterface::RESOURCE_KEY;
+        return ProductInterface::RESOURCE_KEY;
     }
 
     public function getCustomizeWebspaceSettings(): bool

--- a/src/Domain/Model/ProductDimensionContentInterface.php
+++ b/src/Domain/Model/ProductDimensionContentInterface.php
@@ -29,8 +29,6 @@ use Sulu\Content\Domain\Model\WorkflowInterface;
  */
 interface ProductDimensionContentInterface extends DimensionContentInterface, ExcerptInterface, TaxonomyInterface, SeoInterface, TemplateInterface, RoutableInterface, WorkflowInterface, ShadowInterface, WebspaceInterface, AuthorInterface, AuditableInterface
 {
-    public const RESOURCE_KEY = 'product_contents';
-
     public const DEFAULT_STATUS = 'available';
 
     public function getTitle(): ?string;

--- a/src/Infrastructure/Sulu/Admin/ProductAdmin.php
+++ b/src/Infrastructure/Sulu/Admin/ProductAdmin.php
@@ -25,7 +25,6 @@ use Sulu\Component\Localization\Manager\LocalizationManagerInterface;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
 use Sulu\Product\Domain\Association\ProductAssociationTypeRegistry;
-use Sulu\Product\Domain\Model\ProductDimensionContentInterface;
 use Sulu\Product\Domain\Model\ProductInterface;
 
 /**
@@ -185,8 +184,6 @@ class ProductAdmin extends Admin
         $viewCollection->add(
             $this->viewBuilderFactory->createPreviewFormViewBuilder(static::EDIT_TABS_VIEW . '.details', '/details')
                 ->setResourceKey(ProductInterface::RESOURCE_KEY)
-                // the preview object provider is registered for the dimension content, not the product
-                ->setPreviewResourceKey(ProductDimensionContentInterface::RESOURCE_KEY)
                 ->setPreviewCondition('workflowPlace != null')
                 ->setFormKey(ProductInterface::FORM_KEY)
                 ->setTabTitle('sulu_admin.details')

--- a/src/Infrastructure/Sulu/HttpCache/EventSubscriber/ProductCacheInvalidationSubscriber.php
+++ b/src/Infrastructure/Sulu/HttpCache/EventSubscriber/ProductCacheInvalidationSubscriber.php
@@ -106,7 +106,7 @@ class ProductCacheInvalidationSubscriber implements EventSubscriberInterface
             filters: [
                 'resourceKey' => ProductInterface::RESOURCE_KEY,
                 'resourceId' => $removedProductUuid,
-                'referenceResourceKey' => ProductDimensionContentInterface::RESOURCE_KEY,
+                'referenceResourceKey' => ProductInterface::RESOURCE_KEY,
             ],
             fields: ['referenceResourceId', 'referenceLocale'],
             distinct: true,

--- a/src/Infrastructure/Sulu/Reference/ProductAssociationReferenceCleanupSubscriber.php
+++ b/src/Infrastructure/Sulu/Reference/ProductAssociationReferenceCleanupSubscriber.php
@@ -15,7 +15,6 @@ namespace Sulu\Product\Infrastructure\Sulu\Reference;
 
 use Sulu\Bundle\ReferenceBundle\Domain\Repository\ReferenceRepositoryInterface;
 use Sulu\Product\Domain\Event\ProductRemovedEvent;
-use Sulu\Product\Domain\Model\ProductDimensionContentInterface;
 use Sulu\Product\Domain\Model\ProductInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -49,7 +48,7 @@ class ProductAssociationReferenceCleanupSubscriber implements EventSubscriberInt
         $this->referenceRepository->removeBy([
             'resourceKey' => ProductInterface::RESOURCE_KEY,
             'resourceId' => $event->getResourceId(),
-            'referenceResourceKey' => ProductDimensionContentInterface::RESOURCE_KEY,
+            'referenceResourceKey' => ProductInterface::RESOURCE_KEY,
         ]);
     }
 }

--- a/src/Infrastructure/Sulu/Reference/ProductReferenceRefresher.php
+++ b/src/Infrastructure/Sulu/Reference/ProductReferenceRefresher.php
@@ -25,6 +25,7 @@ use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Product\Domain\Model\Product;
 use Sulu\Product\Domain\Model\ProductDimensionContent;
 use Sulu\Product\Domain\Model\ProductDimensionContentInterface;
+use Sulu\Product\Domain\Model\ProductInterface;
 
 /**
  * @internal Modifying or depending on this service may result in unexpected behavior and is not supported.
@@ -55,7 +56,7 @@ class ProductReferenceRefresher implements ReferenceRefresherInterface
      */
     public static function getResourceKey(): string
     {
-        return ProductDimensionContentInterface::RESOURCE_KEY;
+        return ProductInterface::RESOURCE_KEY;
     }
 
     public function refresh(?array $filter = null): \Generator

--- a/src/Infrastructure/Symfony/HttpKernel/SuluProductBundle.php
+++ b/src/Infrastructure/Symfony/HttpKernel/SuluProductBundle.php
@@ -986,7 +986,7 @@ final class SuluProductBundle extends AbstractBundle
                 ProductAdmin::SECURITY_CONTEXT,
             ])
             ->tag('sulu.context', ['context' => 'admin'])
-            ->tag('sulu_preview.object_provider', ['provider-key' => ProductDimensionContentInterface::RESOURCE_KEY]);
+            ->tag('sulu_preview.object_provider', ['provider-key' => ProductInterface::RESOURCE_KEY]);
 
         $services->set('sulu_product.product_teaser_provider')
             ->class(ProductTeaserProvider::class)
@@ -1118,7 +1118,7 @@ final class SuluProductBundle extends AbstractBundle
                 new Reference('sulu_admin.metadata_provider_registry'),
                 new Reference('sulu_http_cache.cache_lifetime.resolver'),
             ])
-            ->tag('sulu_route.route_defaults_provider', ['resource_key' => ProductDimensionContentInterface::RESOURCE_KEY]);
+            ->tag('sulu_route.route_defaults_provider', ['resource_key' => ProductInterface::RESOURCE_KEY]);
 
         $services->set('sulu_product.admin_product_index_listener')
             ->class(AdminProductIndexListener::class)
@@ -1209,14 +1209,9 @@ final class SuluProductBundle extends AbstractBundle
                         ],
                     ],
                     'resources' => [
-                        'products' => [
+                        ProductInterface::RESOURCE_KEY => [
                             'routes' => [
                                 'list' => 'sulu_product.get_products',
-                                'detail' => 'sulu_product.get_product',
-                            ],
-                        ],
-                        ProductDimensionContentInterface::RESOURCE_KEY => [
-                            'routes' => [
                                 'detail' => 'sulu_product.get_product',
                             ],
                         ],

--- a/tests/Functional/Integration/ProductAssociationReferenceCleanupTest.php
+++ b/tests/Functional/Integration/ProductAssociationReferenceCleanupTest.php
@@ -17,7 +17,6 @@ use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use Sulu\Bundle\ReferenceBundle\Domain\Repository\ReferenceRepositoryInterface;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
-use Sulu\Product\Domain\Model\ProductDimensionContentInterface;
 use Sulu\Product\Domain\Model\ProductInterface;
 use Sulu\Product\Infrastructure\Sulu\Reference\ProductAssociationReferenceCleanupSubscriber;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
@@ -117,7 +116,7 @@ final class ProductAssociationReferenceCleanupTest extends SuluTestCase
         return $referenceRepository->findOneBy([
             'resourceKey' => ProductInterface::RESOURCE_KEY,
             'resourceId' => $targetId,
-            'referenceResourceKey' => ProductDimensionContentInterface::RESOURCE_KEY,
+            'referenceResourceKey' => ProductInterface::RESOURCE_KEY,
             'referenceResourceId' => $referrerId,
         ]);
     }

--- a/tests/Unit/Domain/Model/ProductDimensionContentTest.php
+++ b/tests/Unit/Domain/Model/ProductDimensionContentTest.php
@@ -22,7 +22,6 @@ use Sulu\Product\Domain\Model\Product;
 use Sulu\Product\Domain\Model\ProductAssociationInterface;
 use Sulu\Product\Domain\Model\ProductAttributeValue;
 use Sulu\Product\Domain\Model\ProductDimensionContent;
-use Sulu\Product\Domain\Model\ProductDimensionContentInterface;
 use Sulu\Product\Domain\Model\ProductFamily;
 use Sulu\Product\Domain\Model\ProductInterface;
 
@@ -50,7 +49,7 @@ class ProductDimensionContentTest extends TestCase
     public function testGetResourceKeyReturnsExpectedKey(): void
     {
         $this->assertSame(
-            ProductDimensionContentInterface::RESOURCE_KEY,
+            ProductInterface::RESOURCE_KEY,
             ProductDimensionContent::getResourceKey(),
         );
     }

--- a/tests/Unit/Infrastructure/Sulu/Admin/ProductAdminTest.php
+++ b/tests/Unit/Infrastructure/Sulu/Admin/ProductAdminTest.php
@@ -28,7 +28,6 @@ use Sulu\Component\Localization\Manager\LocalizationManagerInterface;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
 use Sulu\Product\Domain\Association\ProductAssociationTypeRegistry;
-use Sulu\Product\Domain\Model\ProductDimensionContentInterface;
 use Sulu\Product\Infrastructure\Sulu\Admin\AttributeAdmin;
 use Sulu\Product\Infrastructure\Sulu\Admin\AttributeGroupAdmin;
 use Sulu\Product\Infrastructure\Sulu\Admin\ProductAdmin;
@@ -244,11 +243,9 @@ class ProductAdminTest extends TestCase
 
         $editView = $viewCollection->get(ProductAdmin::EDIT_TABS_VIEW . '.details')->getView();
         $this->assertSame(PreviewFormViewBuilder::TYPE, $editView->getType());
-        // the preview object provider is tagged for the dimension content, not the product itself
-        $this->assertSame(
-            ProductDimensionContentInterface::RESOURCE_KEY,
-            $editView->getOption('previewResourceKey'),
-        );
+        // the preview object provider is registered for the product resource key, so the view
+        // needs no separate preview resource key
+        $this->assertNull($editView->getOption('previewResourceKey'));
         $this->assertSame('workflowPlace != null', $editView->getOption('previewCondition'));
 
         // nothing to preview before the product exists

--- a/tests/Unit/Infrastructure/Sulu/HttpCache/EventSubscriber/ProductCacheInvalidationSubscriberTest.php
+++ b/tests/Unit/Infrastructure/Sulu/HttpCache/EventSubscriber/ProductCacheInvalidationSubscriberTest.php
@@ -33,7 +33,6 @@ use Sulu\Product\Domain\Event\ProductRemovedEvent;
 use Sulu\Product\Domain\Event\ProductWorkflowTransitionAppliedEvent;
 use Sulu\Product\Domain\Model\Product;
 use Sulu\Product\Domain\Model\ProductDimensionContent;
-use Sulu\Product\Domain\Model\ProductDimensionContentInterface;
 use Sulu\Product\Domain\Model\ProductInterface;
 use Sulu\Product\Domain\Repository\ProductRepositoryInterface;
 use Sulu\Product\Infrastructure\Sulu\HttpCache\EventSubscriber\ProductCacheInvalidationSubscriber;
@@ -334,7 +333,7 @@ class ProductCacheInvalidationSubscriberTest extends TestCase
             [
                 'resourceKey' => ProductInterface::RESOURCE_KEY,
                 'resourceId' => 'product-uuid-456',
-                'referenceResourceKey' => ProductDimensionContentInterface::RESOURCE_KEY,
+                'referenceResourceKey' => ProductInterface::RESOURCE_KEY,
             ],
             [],
             ['referenceResourceId', 'referenceLocale'],
@@ -378,7 +377,7 @@ class ProductCacheInvalidationSubscriberTest extends TestCase
             [
                 'resourceKey' => ProductInterface::RESOURCE_KEY,
                 'resourceId' => 'product-uuid-456',
-                'referenceResourceKey' => ProductDimensionContentInterface::RESOURCE_KEY,
+                'referenceResourceKey' => ProductInterface::RESOURCE_KEY,
             ],
             [],
             ['referenceResourceId', 'referenceLocale'],

--- a/tests/Unit/Infrastructure/Sulu/Reference/ProductAssociationReferenceCleanupSubscriberTest.php
+++ b/tests/Unit/Infrastructure/Sulu/Reference/ProductAssociationReferenceCleanupSubscriberTest.php
@@ -20,7 +20,6 @@ use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\ReferenceBundle\Domain\Repository\ReferenceRepositoryInterface;
 use Sulu\Product\Domain\Event\ProductRemovedEvent;
-use Sulu\Product\Domain\Model\ProductDimensionContentInterface;
 use Sulu\Product\Domain\Model\ProductInterface;
 use Sulu\Product\Infrastructure\Sulu\Reference\ProductAssociationReferenceCleanupSubscriber;
 
@@ -60,7 +59,7 @@ final class ProductAssociationReferenceCleanupSubscriberTest extends TestCase
         $this->referenceRepository->removeBy([
             'resourceKey' => ProductInterface::RESOURCE_KEY,
             'resourceId' => 'uuid-b',
-            'referenceResourceKey' => ProductDimensionContentInterface::RESOURCE_KEY,
+            'referenceResourceKey' => ProductInterface::RESOURCE_KEY,
         ])->shouldHaveBeenCalledOnce();
     }
 

--- a/tests/Unit/Infrastructure/Sulu/Reference/ProductReferenceRefresherTest.php
+++ b/tests/Unit/Infrastructure/Sulu/Reference/ProductReferenceRefresherTest.php
@@ -31,6 +31,7 @@ use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Product\Domain\Model\Product;
 use Sulu\Product\Domain\Model\ProductDimensionContent;
 use Sulu\Product\Domain\Model\ProductDimensionContentInterface;
+use Sulu\Product\Domain\Model\ProductInterface;
 use Sulu\Product\Infrastructure\Sulu\Reference\ProductReferenceRefresher;
 
 class ProductReferenceRefresherTest extends TestCase
@@ -78,7 +79,7 @@ class ProductReferenceRefresherTest extends TestCase
 
     public function testGetResourceKeyMatchesTheKeyTheRefreshersAreIndexedBy(): void
     {
-        $this->assertSame(ProductDimensionContentInterface::RESOURCE_KEY, ProductReferenceRefresher::getResourceKey());
+        $this->assertSame(ProductInterface::RESOURCE_KEY, ProductReferenceRefresher::getResourceKey());
     }
 
     public function testRefreshReturnsGenerator(): void


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | #403
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

The bundle used two resource keys where the core content types use one. `ProductInterface::RESOURCE_KEY` was `products`, while `ProductDimensionContentInterface::RESOURCE_KEY` was `product_contents`. This PR removes the second one.

* `ProductDimensionContent::getResourceKey()` now returns `ProductInterface::RESOURCE_KEY`, the same way `PageDimensionContent`, `ArticleDimensionContent` and `SnippetDimensionContent` return theirs.
* The preview object provider tag, the route defaults provider tag, `ProductReferenceRefresher` and the two reference subscribers move to `products`.
* The `product_contents` entry in the registered resources is gone. Its only route was `detail: sulu_product.get_product`, which is what the `products` entry already declares.
* `ProductAdmin` no longer needs `setPreviewResourceKey()` on the details form. The provider now sits on the same key the view already uses, so the frontend falls back to it on its own.
* `ProductDimensionContentInterface::RESOURCE_KEY` is removed, since nothing refers to it any more.

Verified in the browser. The preview iframe renders under `provider=products`, a published product still resolves on the website through the route defaults provider, and the versions view now derives `products_versions` on its own.

#### Why?

`ContentViewBuilderFactory::createViews()` builds the content views from `$dimensionContentClass::getResourceKey()`, so the second key made the bundle diverge from every core content type and forced overrides at the call sites. The versions view is the clearest case. It derives its keys the same way and landed on `product_contents_versions`, which nothing declares. See #403 for the workaround this removes the need for.

Nothing in the bundle needed the split. `ProductRouteDefaultsProvider` even resolves the product by uuid, so `products` is the more accurate key there anyway.

#### BC break

Two columns hold the old key and have to be updated. There is no released version on this branch, so this only affects development and staging installs.

```sql
UPDATE ro_routes     SET resource_key         = 'products' WHERE resource_key         = 'product_contents';
UPDATE re_references SET referenceResourceKey = 'products' WHERE referenceResourceKey = 'product_contents';
```

References can be rebuilt with `sulu:reference:refresh` instead. Routes have no refresh command, so they need the statement above. Product pages return 404 on the website until the route rows are updated.

#### To Do

- [ ] Add breaking changes to UPGRADE.md
