### PR TITLE
Unblock CI and close the coverage gap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,9 @@
         "twig/twig": "^3.0",
         "webmozart/assert": "^1.0 || ^2.0"
     },
+    "conflict": {
+        "doctrine/orm": "3.7.x-dev"
+    },
     "require-dev": {
         "ext-filter": "*",
         "handcraftedinthealps/code-coverage-checker": "^0.2.1",

--- a/tests/Unit/Infrastructure/Sulu/Admin/ProductsListMetadataVisitorTest.php
+++ b/tests/Unit/Infrastructure/Sulu/Admin/ProductsListMetadataVisitorTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Product\Tests\Unit\Infrastructure\Sulu\Admin;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\AdminBundle\Metadata\ListMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\ListMetadata\ListMetadata;
+use Sulu\Product\Domain\Model\ProductInterface;
+use Sulu\Product\Infrastructure\Sulu\Admin\ProductsListMetadataVisitor;
+
+#[CoversClass(ProductsListMetadataVisitor::class)]
+class ProductsListMetadataVisitorTest extends TestCase
+{
+    public function testInjectsConfiguredStatusOptions(): void
+    {
+        $statusField = new FieldMetadata('status');
+
+        $listMetadata = new ListMetadata();
+        $listMetadata->addField($statusField);
+
+        $visitor = new ProductsListMetadataVisitor(['announced', 'available']);
+        $visitor->visitListMetadata($listMetadata, ProductInterface::LIST_KEY, 'en');
+
+        $this->assertSame(
+            ['options' => [
+                'announced' => 'sulu_product.product_status.announced',
+                'available' => 'sulu_product.product_status.available',
+            ]],
+            $statusField->getFilterTypeParameters(),
+        );
+    }
+
+    public function testLeavesOtherListsAlone(): void
+    {
+        $statusField = new FieldMetadata('status');
+
+        $listMetadata = new ListMetadata();
+        $listMetadata->addField($statusField);
+
+        $visitor = new ProductsListMetadataVisitor(['announced', 'available']);
+        $visitor->visitListMetadata($listMetadata, ProductInterface::LIST_KEY_VARIANTS, 'en');
+
+        $this->assertNull($statusField->getFilterTypeParameters());
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Two independent things that keep the pipeline red on every pull request.

* **`doctrine/orm: 3.7.x-dev` is added to `conflict`**, the same entry sulu/sulu carries on 3.0. The PHP 8.5 job is the only one that sets `minimum-stability: dev`, so it resolves unreleased branches. On `orm 3.7.x-dev` the schema tool emits foreign keys without a constraint name, MySQL falls back to its own `<table>_ibfk_N` scheme, and any table name longer than 57 characters exceeds the 64 character identifier limit. `sn_snippet_dimension_content_excerpt_audience_target_groups` is 59, so bootstrapping the test environment dies before PHPUnit even starts.
* **`ProductsListMetadataVisitor` gets a unit test.** The class was only reached through `ProductsListFiltersTest`, which always hits it with the products list key, so the early return for every other list was never executed. That single line held line coverage at 99.98% and failed the 100% gate.

#### Why?

Both failures are inherited rather than introduced, so every pull request against 3.0 shows four red jobs and reviewers have to know which ones to ignore.

The conflict was verified rather than assumed. Resolving with `minimum-stability: dev` still installs `doctrine/dbal 4.5.x-dev`, so the question was whether blocking the ORM alone is enough. Bootstrapping the test environment against MySQL 8.4 with `orm 3.6.x-dev` and `dbal 4.5.x-dev` creates the schema in 320 queries and names the foreign keys `FK_87109F5824FF092E` and `FK_87109F587891499D`. The regression is in the ORM, not in DBAL, and the single conflict entry covers it.

Coverage goes from 99.98% (4410/4411) to 100.00% (4411/4411).

#### To Do

- [ ] Create a documentation PR
