### PR TITLE
Fix the product list publish indicator and icon

### DIFF
--- a/config/lists/products.xml
+++ b/config/lists/products.xml
@@ -180,6 +180,15 @@
             <entity-name>dimensionContent</entity-name>
         </property>
 
+        <property name="published" translation="sulu_admin.published" type="date" visibility="never">
+            <field-name>workflowPublished</field-name>
+            <entity-name>dimensionContent</entity-name>
+
+            <joins ref="dimensionContent"/>
+
+            <transformer type="datetime"/>
+        </property>
+
         <property name="publishedState" translation="sulu_content.published_state" visibility="never">
             <field-name>workflowPlace</field-name>
             <entity-name>dimensionContent</entity-name>

--- a/src/Infrastructure/Sulu/Admin/ProductAdmin.php
+++ b/src/Infrastructure/Sulu/Admin/ProductAdmin.php
@@ -61,7 +61,7 @@ class ProductAdmin extends Admin
 
         $parent = new NavigationItem('sulu_product.products');
         $parent->setPosition(20);
-        $parent->setIcon('su-newspaper');
+        $parent->setIcon('su-industry');
 
         if ($hasProducts) {
             $productsChild = new NavigationItem('sulu_product.products');

--- a/src/Infrastructure/Symfony/HttpKernel/SuluProductBundle.php
+++ b/src/Infrastructure/Symfony/HttpKernel/SuluProductBundle.php
@@ -1268,7 +1268,7 @@ final class SuluProductBundle extends AbstractBundle
                                         'adapter' => 'table',
                                         'list_key' => 'products',
                                         'display_properties' => ['name'],
-                                        'icon' => 'su-newspaper',
+                                        'icon' => 'su-industry',
                                         'label' => 'sulu_product.selection_label',
                                         'overlay_title' => 'sulu_product.selection_overlay_title',
                                     ],
@@ -1286,7 +1286,7 @@ final class SuluProductBundle extends AbstractBundle
                                         // the selected item is loaded from the detail endpoint, which has no `name`
                                         'display_properties' => ['title'],
                                         'empty_text' => 'sulu_product.no_product_selected',
-                                        'icon' => 'su-newspaper',
+                                        'icon' => 'su-industry',
                                         'overlay_title' => 'sulu_product.single_selection_overlay_title',
                                     ],
                                 ],
@@ -1411,7 +1411,7 @@ final class SuluProductBundle extends AbstractBundle
                         'resources' => [
                             ProductInterface::RESOURCE_KEY => [
                                 'name' => 'sulu_product.products',
-                                'icon' => 'su-newspaper',
+                                'icon' => 'su-industry',
                                 'route' => [
                                     'name' => ProductAdmin::EDIT_TABS_VIEW . '.details',
                                     'resultToRoute' => [

--- a/src/UserInterface/Controller/Admin/ProductController.php
+++ b/src/UserInterface/Controller/Admin/ProductController.php
@@ -25,6 +25,7 @@ use Sulu\Component\Security\SecuredControllerInterface;
 use Sulu\Content\Application\ContentManager\ContentManagerInterface;
 use Sulu\Content\Domain\Exception\ContentNotFoundException;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Content\Domain\Model\WorkflowInterface;
 use Sulu\Content\Infrastructure\Doctrine\DimensionContentQueryEnhancer;
 use Sulu\Messenger\Infrastructure\Symfony\Messenger\FlushMiddleware\EnableFlushStamp;
 use Sulu\Product\Application\Message\ApplyWorkflowTransitionProductMessage;
@@ -80,6 +81,9 @@ final class ProductController implements SecuredControllerInterface
         $listBuilder = $this->listBuilderFactory->create(ProductInterface::class);
         $listBuilder->setIdField($fieldDescriptors['id']);
         $this->restHelper->initializeListBuilder($listBuilder, $fieldDescriptors);
+        // the publish indicator is rendered from these two, whether or not the list requests them
+        $listBuilder->addSelectField($fieldDescriptors['published']);
+        $listBuilder->addSelectField($fieldDescriptors['publishedState']);
         $listBuilder->setParameter('locale', $this->getLocale($request));
         // Variants are edited through their parent's variants tab and must not show up in the main list.
         $listBuilder->where(
@@ -96,8 +100,15 @@ final class ProductController implements SecuredControllerInterface
             $listBuilder->count(),
         );
 
+        /** @var array{_embedded: array{products: array<int, array<string, mixed>>}} $list */
+        $list = $listRepresentation->toArray();
+        foreach ($list['_embedded'][ProductInterface::RESOURCE_KEY] as &$item) {
+            // the admin expects a boolean, the list builder returns the raw workflow place
+            $item['publishedState'] = WorkflowInterface::WORKFLOW_PLACE_PUBLISHED === ($item['publishedState'] ?? null);
+        }
+
         return new JsonResponse($this->normalizer->normalize(
-            $listRepresentation->toArray(),
+            $list,
             'json',
         ));
     }

--- a/tests/Functional/Integration/ProductControllerTest.php
+++ b/tests/Functional/Integration/ProductControllerTest.php
@@ -848,4 +848,39 @@ class ProductControllerTest extends SuluTestCase
         $this->assertArrayHasKey('title', $data);
         $this->assertSame('Selectable Product', $data['title']);
     }
+
+    public function testListExposesThePublishStateForTheIndicator(): void
+    {
+        self::purgeDatabase();
+        $familyId = $this->createProductFamily();
+        $draftId = $this->createProduct($familyId, 'Draft Product');
+        $publishedId = $this->createProduct($familyId, 'Published Product');
+
+        $this->client->request('POST', '/admin/api/products/' . $publishedId . '.json?locale=en&action=publish');
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
+
+        // the list does not ask for either field, the indicator needs them anyway
+        $this->client->request('GET', '/admin/api/products.json?locale=en&fields=name,id&flat=true');
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        $data = \json_decode((string) $response->getContent(), true);
+        $this->assertIsArray($data);
+        $this->assertIsArray($data['_embedded']);
+        $this->assertIsArray($data['_embedded']['products']);
+
+        $byId = [];
+        foreach ($data['_embedded']['products'] as $item) {
+            $this->assertIsArray($item);
+            $this->assertIsString($item['id']);
+            $byId[$item['id']] = $item;
+        }
+
+        // the admin derives the circle from a boolean state plus a publish date
+        $this->assertFalse($byId[$draftId]['publishedState']);
+        $this->assertNull($byId[$draftId]['published']);
+
+        $this->assertTrue($byId[$publishedId]['publishedState']);
+        $this->assertNotNull($byId[$publishedId]['published']);
+    }
 }

--- a/tests/Unit/Infrastructure/Sulu/Admin/ProductAdminTest.php
+++ b/tests/Unit/Infrastructure/Sulu/Admin/ProductAdminTest.php
@@ -97,6 +97,7 @@ class ProductAdminTest extends TestCase
         $this->assertCount(1, $items);
         $parent = \reset($items);
         $this->assertCount(2, $parent->getChildren());
+        $this->assertSame('su-industry', $parent->getIcon());
     }
 
     public function testConfigureNavigationItemsOnlyProducts(): void


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

* **The publish indicator in the product list never showed a state.** `AbstractTableAdapter` reads `const draft = !item.publishedState` and `const published = !!item.published`. The list returned the raw workflow place as a string, which is always truthy, so `draft` was permanently false, and no `published` property was returned at all. Every row rendered the same, whether it was published, unpublished or carrying draft changes.
* `config/lists/products.xml` gains the `published` property that the articles list already declares, mapped to `workflowPublished` with a datetime transformer.
* `ProductController::cgetAction()` selects `published` and `publishedState` whether or not the list asked for them, then maps the workflow place to a boolean. This mirrors what `ArticleController` does.
* **The navigation icon changes from `su-newspaper` to `su-industry`.** The selection overlays and the search result entry move with it, so a product looks the same wherever it appears. `ProductLinkProvider` keeps `su-document`, which is what the article link provider uses too.

Before and after for the same list request, with neither field requested:

```
{"publishedState": "draft"}
{"publishedState": false, "published": "2026-07-23T18:04:31+00:00"}
```

#### Why?

The indicator is the only place in the list that tells an editor whether a product is live, so a product with unpublished changes looked exactly like one that was fully published.

The new functional test covers both states, including the unpublished one, and asserts that the two fields come back even when the request asks only for `name` and `id`.

#### To Do

- [ ] Create a documentation PR
